### PR TITLE
Point function-mesh ConfigMap at the in-cluster proxy

### DIFF
--- a/function-mesh-operator/configs/00-config-maps.yaml
+++ b/function-mesh-operator/configs/00-config-maps.yaml
@@ -4,8 +4,8 @@ kind: ConfigMap
 metadata:
   name: pulsar
 data:
-  webServiceURL: http://<BROKER-URL>:8080
-  brokerServiceURL: pulsar://<BROKER-URL>:6650
+  webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local:8080
+  brokerServiceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local:6650
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Replaces the `<BROKER-URL>` placeholder in the Function Mesh pulsar connection ConfigMap with the Oxia cluster's **ClusterIP** proxy FQDN (not the LoadBalancer):

```
webServiceURL:    http://private-cloud-proxy.pulsar.svc.cluster.local:8080
brokerServiceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local:6650
```

## Verification
Applied the ConfigMap + the getting-started `FunctionMesh` (ex1 → ex2) into the `pulsar` namespace:
- Both functions reached `FunctionReady` / mesh `MeshReady=True` (they connect to Pulsar via the proxy URL above).
- Produced 20 messages to `functionmesh-input-topic`; all 20 emerged on `functionmesh-output-topic` as `Hello Function Mesh!!` (double `!` confirms both functions in the chain processed each message).

> Note: the Java sample functions take several minutes to fully establish their Pulsar source/sink subscriptions even after the pod reports `Ready` — produce test traffic only after the input/mid-topic subscriptions exist, or messages are dropped (no retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)