### PR TITLE
Add operator-managed HPA + topology spread for brokers

### DIFF
--- a/function-mesh-operator/configs/00-config-maps.yaml
+++ b/function-mesh-operator/configs/00-config-maps.yaml
@@ -4,8 +4,8 @@ kind: ConfigMap
 metadata:
   name: pulsar
 data:
-  webServiceURL: http://<BROKER-URL>:8080
-  brokerServiceURL: pulsar://<BROKER-URL>:6650
+  webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local:8080
+  brokerServiceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local:6650
 ---
 apiVersion: v1
 kind: Secret

--- a/pulsar-operators/configs/02-pulsar-oxia.yaml
+++ b/pulsar-operators/configs/02-pulsar-oxia.yaml
@@ -5,12 +5,15 @@
 #
 # Local-lab customizations:
 #   - image: streamnative/private-cloud:4.2.1.4 (latest)
-#   - broker replicas: 2
+#   - broker replicas: 2, with an operator-managed HPA (autoScalingPolicy)
+#     scaling on CPU (60% util) between 2 and 6 replicas.
 #   - resources: broker / bookie / oxia each request 1 core + 4Gi
 #   - BookKeeper storage on local classes: journal -> nvme-raid, ledger -> ssd-raid (200Gi)
 #   - Oxia server data -> nvme-raid
-#   - podAntiAffinity (hostname) on broker / bookie / oxia so same-type pods
-#     spread one-per-node across the 3 k8s nodes.
+#   - required podAntiAffinity (hostname) on bookie / oxia so same-type pods
+#     spread one-per-node across the 3 k8s nodes (also avoids local-PVC pinning issues).
+#   - broker uses topologySpreadConstraints (maxSkew 1, ScheduleAnyway) instead:
+#     one broker per node first, then HPA adds extra replicas onto existing nodes.
 #
 # Apply after the operator + license are installed (instead of 01-pulsar-cluster.yaml):
 #   kubectl apply -f ./pulsar-operators/configs/02-pulsar-oxia.yaml
@@ -225,6 +228,19 @@ metadata:
 spec:
   image: streamnative/private-cloud:4.2.1.4
   replicas: 2
+  # Operator-managed HPA. Brokers spread one-per-node first (topologySpreadConstraints
+  # in pod.spec below), then HPA can add more onto existing nodes up to maxReplicas
+  # (6 = up to 2 brokers per node across 3 nodes).
+  autoScalingPolicy:
+    minReplicas: 2
+    maxReplicas: 6
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
   bkMetadataServiceUri: metadata-store:oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/bookkeeper
   # Use the oxia namespace address for broker metadata
   metadataStoreUrl: oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/broker
@@ -257,14 +273,18 @@ spec:
       requests:
         cpu: "1"
         memory: 4Gi
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                cloud.streamnative.io/cluster: private-cloud
-                cloud.streamnative.io/component: broker
-            topologyKey: kubernetes.io/hostname
+    # Brokers are stateless, so they don't need hard one-per-node placement.
+    # topologySpreadConstraints fills one broker per node first, then balances
+    # additional replicas (HPA scale-up beyond 3) evenly onto existing nodes
+    # (maxSkew 1 + ScheduleAnyway). oxia/bookie keep required anti-affinity.
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            cloud.streamnative.io/cluster: private-cloud
+            cloud.streamnative.io/component: broker
     securityContext:
       runAsNonRoot: true
 ---


### PR DESCRIPTION
Enables horizontal autoscaling for the Pulsar brokers, using the metrics-server (already enabled in microk8s).

## What changed (`pulsar-operators/configs/02-pulsar-oxia.yaml`)
- **Operator-managed HPA** via `PulsarBroker.spec.autoScalingPolicy`: CPU `averageUtilization: 60`, `minReplicas: 2`, `maxReplicas: 6`. The operator owns the HPA, which targets the `PulsarBroker` `/scale` subresource — no operator/HPA conflict.
- **Broker placement** switched from `required` podAntiAffinity to `topologySpreadConstraints` (`maxSkew: 1`, `whenUnsatisfiable: ScheduleAnyway`): one broker per node first, then additional replicas balance onto existing nodes.

oxia and bookie intentionally **keep** `required` anti-affinity (metadata-store SPOF + local-PVC node pinning).

## Why topology spread instead of anti-affinity
`required` anti-affinity hard-caps brokers at one-per-node (3 on this 3-node cluster); a 4th would sit `Pending`. Brokers are stateless, so soft balanced spread is the right fit for scaling.

| Replicas | node00 | node01 | node02 |
|---|---|---|---|
| 3 | 1 | 1 | 1 |
| 4 | 2 | 1 | 1 |
| 5 | 2 | 2 | 1 |
| 6 | 2 | 2 | 2 |

## Verification
- metrics-server healthy; HPA reads `1%/60%`, min 2 / max 6.
- Forced `minReplicas=4`: the 4th broker scheduled onto an existing node (per-node count 2/1/1), **none Pending**. Reverted to min 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)