### PR TITLE
Enable JWT authentication + broker TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ bin/
 pulsar-operators/configs/00-license-secret.yaml
 *sn-license*.key
 *-license.key
+
+### Pulsar JWT auth — never commit the signing key or tokens ###
+# Generated locally with snctl; recreate the k8s secrets from these (see README).
+token-private.key
+token-public.key
+*.token

--- a/pulsar-operators/README.md
+++ b/pulsar-operators/README.md
@@ -175,6 +175,36 @@ snctl context update-external private-cloud --token "$(cat broker-admin.token)"
 snctl pulsar admin tenants list      # works with token; 401 without
 ```
 
+### TLS (encryption in transit)
+
+`03-pulsar-tls.yaml` provisions the certs with **cert-manager** (self-signed CA →
+CA issuer → server cert with broker/proxy SANs + the LB IP). Install cert-manager
+first (`kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml`),
+then `kubectl apply -f ./pulsar-operators/configs/03-pulsar-tls.yaml`.
+
+The **broker** uses the operator-native `spec.tls` (`certSecretName: pulsar-server-tls`),
+which mounts the cert at `/etc/tls/pulsar-broker/` and enables both the web TLS port
+(8443) and the binary TLS listener (`pulsar+ssl://…:6651` via `advertisedListeners`).
+Do **not** also set `PULSAR_PREFIX_brokerServicePortTls` — it double-binds 6651 and
+crashloops the broker. Verify (from a broker pod):
+
+```bash
+# binary TLS
+./bin/pulsar-client --url pulsar+ssl://localhost:6651 \
+  --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+  --auth-params "token:$(cat broker-admin.token)" \
+  --tlsTrustCertsFilePath /etc/tls/pulsar-broker/ca.crt \
+  produce public/default/t -m hi -n 1
+# admin/web TLS
+curl --cacert /etc/tls/pulsar-broker/ca.crt -H "Authorization: Bearer <token>" \
+  https://localhost:8443/admin/v2/clusters
+```
+
+> **Known limitation (follow-up):** proxy / external **LoadBalancer** TLS is not
+> enabled. In operator v0.18.14 the proxy Service/LoadBalancer doesn't publish the
+> TLS ports (6651/8443) — neither `certSecretName` nor `config.custom` gets them
+> exposed — so external clients still use plaintext + token via the LB.
+
 ### Cleanup
 
 ```bash

--- a/pulsar-operators/README.md
+++ b/pulsar-operators/README.md
@@ -133,6 +133,48 @@ Port-forward the console:
 kubectl port-forward private-cloud-console-0 9527:9527 -n pulsar
 ```
 
+### JWT authentication (token auth)
+
+`02-pulsar-oxia.yaml` is wired for JWT/token authentication
+(`AuthenticationProviderToken`) per the
+[StreamNative private-cloud JWT auth guide](https://docs.streamnative.io/private-cloud/v2/configure-private-cloud/security/authentication/private-cloud-jwt-auth).
+The manifest references four secrets that you generate locally (keys/tokens are
+**never** committed — see `.gitignore`):
+
+```bash
+# 1) RS256 key pair (snctl == pulsarctl token tooling)
+snctl pulsar admin token create-key-pair \
+  --output-private-key token-private.key --output-public-key token-public.key
+
+# 2) Mint subject tokens (stdout is on stderr; capture both)
+for s in broker-admin proxy-admin client; do
+  snctl pulsar admin token create --private-key-file token-private.key --subject "$s" 2>&1 \
+    | grep -oE 'eyJ[A-Za-z0-9_.-]+' > "$s.token"
+done
+
+# 3) Create the secrets the manifest expects (pulsar namespace)
+kubectl create secret generic token-public-key -n pulsar --from-file=my-public.key=token-public.key
+kubectl create secret generic broker-admin -n pulsar --from-file=token=broker-admin.token
+kubectl create secret generic proxy-admin  -n pulsar --from-file=token=proxy-admin.token
+kubectl create secret generic client       -n pulsar --from-file=token=client.token
+```
+
+Key points in the manifest:
+
+- Keys live under `config.custom` as `PULSAR_PREFIX_*` (this cluster sets
+  `enable-config-prefix: false`, so custom keys pass through verbatim).
+- `superUserRoles: broker-admin,proxy-admin`; **`proxyRoles: proxy-admin`** is
+  required so the broker trusts the proxy to forward the original client identity.
+- `config.clientAuth.jwt.secret` + `pod.vars` provide each component's own client token;
+  `pod.secretRefs` mounts the public key at `/mnt/secrets/my-public.key`.
+
+Point `snctl` at the cluster with a superuser token:
+
+```bash
+snctl context update-external private-cloud --token "$(cat broker-admin.token)"
+snctl pulsar admin tenants list      # works with token; 401 without
+```
+
 ### Cleanup
 
 ```bash

--- a/pulsar-operators/configs/02-pulsar-oxia.yaml
+++ b/pulsar-operators/configs/02-pulsar-oxia.yaml
@@ -241,6 +241,14 @@ spec:
           target:
             type: Utilization
             averageUtilization: 60
+  # TLS (encryption in transit). The operator mounts the cert-manager secret at
+  # /etc/tls/pulsar-broker/ and configures BOTH the web TLS port (8443) and the
+  # binary TLS listener (cluster_tls:pulsar+ssl://...:6651 via advertisedListeners
+  # /bindAddresses). Do NOT also set brokerServicePortTls — it double-binds 6651.
+  tls:
+    enabled: true
+    certSecretName: pulsar-server-tls
+    trustCertsEnabled: true
   bkMetadataServiceUri: metadata-store:oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/bookkeeper
   # Use the oxia namespace address for broker metadata
   metadataStoreUrl: oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/broker
@@ -342,6 +350,10 @@ spec:
   image: streamnative/private-cloud:4.2.1.4
   replicas: 1
   brokerAddress: private-cloud-broker
+  # NOTE: proxy/external (LoadBalancer) TLS is NOT enabled. In operator v0.18.14
+  # neither `certSecretName` nor config.custom TLS gets the proxy Service/LB to
+  # publish the TLS ports (6651/8443), so external clients use plaintext+token.
+  # Broker TLS (below, spec.tls) works for direct/internal connections. Follow-up.
   config:
     # JWT/token auth: proxy authenticates clients and forwards their identity
     # to the broker (authenticateOriginalAuthData + forwardAuthorizationCredentials).

--- a/pulsar-operators/configs/02-pulsar-oxia.yaml
+++ b/pulsar-operators/configs/02-pulsar-oxia.yaml
@@ -249,6 +249,11 @@ spec:
   config:
     clusterName: private-cloud
     useStorageCatalog: true
+    # JWT/token auth: the operator wires the broker's internal client identity
+    # (brokerClientAuthenticationParameters) from the broker-admin token secret.
+    clientAuth:
+      jwt:
+        secret: broker-admin
     custom:
       PULSAR_PREFIX_metadataStoreUrl: oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/broker
       PULSAR_PREFIX_configurationMetadataStoreUrl: oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/broker
@@ -261,6 +266,20 @@ spec:
       PULSAR_PREFIX_schemaRegistryUrl: oxia://private-cloud-oxia.pulsar.svc.cluster.local:6648/kafka-schema
       PULSAR_PREFIX_schemaRegistryStorageClassName: io.streamnative.pulsar.schema.OxiaSchemaStorageFactory
       PULSAR_PREFIX_topicPoliciesServiceClassName: io.streamnative.pulsar.OxiaTopicPoliciesService
+      # --- JWT/token authentication (per StreamNative private-cloud JWT auth doc).
+      # Keys are PULSAR_PREFIX_-prefixed because this cluster sets
+      # enable-config-prefix=false (operator passes config.custom through verbatim).
+      PULSAR_PREFIX_authenticationEnabled: "true"
+      PULSAR_PREFIX_authenticateOriginalAuthData: "true"
+      PULSAR_PREFIX_authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderToken
+      PULSAR_PREFIX_authorizationEnabled: "true"
+      PULSAR_PREFIX_authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
+      PULSAR_PREFIX_superUserRoles: broker-admin,proxy-admin
+      # proxy-admin is a proxy role, so the broker trusts it to forward the
+      # original client principal (required for client auth via the proxy).
+      PULSAR_PREFIX_proxyRoles: proxy-admin
+      PULSAR_PREFIX_brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+      PULSAR_PREFIX_tokenPublicKey: file:///mnt/secrets/my-public.key
     function:
       enabled: false
       mesh:
@@ -273,6 +292,16 @@ spec:
       requests:
         cpu: "1"
         memory: 4Gi
+    # Mount the JWT public key for token validation.
+    secretRefs:
+      - mountPath: /mnt/secrets
+        secretName: token-public-key
+    vars:
+      - name: brokerClientAuthenticationParameters
+        valueFrom:
+          secretKeyRef:
+            name: broker-admin
+            key: token
     # Brokers are stateless, so they don't need hard one-per-node placement.
     # topologySpreadConstraints fills one broker per node first, then balances
     # additional replicas (HPA scale-up beyond 3) evenly onto existing nodes
@@ -313,6 +342,20 @@ spec:
   image: streamnative/private-cloud:4.2.1.4
   replicas: 1
   brokerAddress: private-cloud-broker
+  config:
+    # JWT/token auth: proxy authenticates clients and forwards their identity
+    # to the broker (authenticateOriginalAuthData + forwardAuthorizationCredentials).
+    clientAuth:
+      jwt:
+        secret: proxy-admin
+    custom:
+      PULSAR_PREFIX_authenticationEnabled: "true"
+      PULSAR_PREFIX_authenticateOriginalAuthData: "true"
+      PULSAR_PREFIX_forwardAuthorizationCredentials: "true"
+      PULSAR_PREFIX_authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderToken
+      PULSAR_PREFIX_brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+      PULSAR_PREFIX_superUserRoles: proxy-admin
+      PULSAR_PREFIX_tokenPublicKey: file:///mnt/secrets/my-public.key
   pod:
     annotations:
       prometheus.io/port: "8080"
@@ -321,5 +364,14 @@ spec:
       requests:
         cpu: 200m
         memory: 512Mi
+    secretRefs:
+      - mountPath: /mnt/secrets
+        secretName: token-public-key
+    vars:
+      - name: brokerClientAuthenticationParameters
+        valueFrom:
+          secretKeyRef:
+            name: proxy-admin
+            key: token
     securityContext:
       runAsNonRoot: true

--- a/pulsar-operators/configs/03-pulsar-tls.yaml
+++ b/pulsar-operators/configs/03-pulsar-tls.yaml
@@ -1,0 +1,65 @@
+# cert-manager TLS for the private-cloud Pulsar cluster.
+# Self-signed root CA -> CA issuer -> server cert (broker + proxy SANs + LB IP).
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: pulsar-selfsigned
+  namespace: pulsar
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pulsar-ca
+  namespace: pulsar
+spec:
+  isCA: true
+  commonName: private-cloud-pulsar-ca
+  secretName: pulsar-ca-tls
+  duration: 87600h    # 10y
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: pulsar-selfsigned
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: pulsar-ca-issuer
+  namespace: pulsar
+spec:
+  ca:
+    secretName: pulsar-ca-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pulsar-server-tls
+  namespace: pulsar
+spec:
+  secretName: pulsar-server-tls
+  duration: 8760h     # 1y
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: pulsar-ca-issuer
+    kind: Issuer
+  dnsNames:
+    - private-cloud-broker
+    - private-cloud-broker.pulsar.svc
+    - private-cloud-broker.pulsar.svc.cluster.local
+    - private-cloud-broker-headless.pulsar.svc.cluster.local
+    - "*.private-cloud-broker-headless.pulsar.svc.cluster.local"
+    - private-cloud-proxy
+    - private-cloud-proxy.pulsar.svc
+    - private-cloud-proxy.pulsar.svc.cluster.local
+    - private-cloud-proxy-headless.pulsar.svc.cluster.local
+    - "*.private-cloud-proxy-headless.pulsar.svc.cluster.local"
+    - localhost
+  ipAddresses:
+    - 192.168.0.200
+    - 127.0.0.1


### PR DESCRIPTION
Adds **JWT/token authentication** and **broker TLS** to the Oxia cluster. Two clean, separate commits:

1. **JWT auth** (`AuthenticationProviderToken`) per the [private-cloud JWT auth guide](https://docs.streamnative.io/private-cloud/v2/configure-private-cloud/security/authentication/private-cloud-jwt-auth) — broker + proxy, `superUserRoles`, **`proxyRoles: proxy-admin`** (so clients via the proxy work on the binary protocol), `clientAuth.jwt` + `pod.vars` for internal identity, key/token gen via `snctl`. `config.custom` uses `PULSAR_PREFIX_` (cluster has `enable-config-prefix: false`).
2. **Broker TLS** via **cert-manager** (`03-pulsar-tls.yaml`: self-signed CA → server cert with SANs + LB IP). Broker `spec.tls` enables web TLS (8443) + binary TLS (`pulsar+ssl://6651` via `advertisedListeners`). Gotcha: do **not** also set `brokerServicePortTls` (double-binds 6651).

## Verified (live)
- Auth: no token → 401; superuser token → full admin; `client` token (granted perms) → produce/consume via proxy over `pulsar://`.
- TLS: produce/consume over `pulsar+ssl://6651` and admin over `https://8443` (CA + token).

## Known limitation (follow-up)
Proxy / external **LoadBalancer** TLS is not enabled — operator v0.18.14 doesn't publish the proxy TLS service ports (6651/8443), so external clients use plaintext+token via the LB. Documented in the manifest + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)