### PR TITLE
Add snmcp MCP server + one-command deploy.sh

### DIFF
--- a/pulsar-operators/README.md
+++ b/pulsar-operators/README.md
@@ -13,6 +13,21 @@ A single `sn-operator` reconciles a `PulsarCoordinator` plus the component CRs
 | `configs/01-pulsar-cluster.yaml` | ZooKeeper (default) | works on older operators |
 | `configs/02-pulsar-oxia.yaml` | Oxia (no ZooKeeper) | needs a recent `sn-operator` — see note below |
 
+### One-command deploy
+
+`deploy.sh` brings up the whole MCP-enhanced stack end to end — operator → license →
+JWT auth secrets → cert-manager/TLS → Oxia cluster → the snmcp MCP server:
+
+```bash
+# provide a license first (see step 2️⃣), then:
+./pulsar-operators/deploy.sh
+# microk8s:
+KUBECTL="microk8s kubectl" HELM="microk8s helm3" ./pulsar-operators/deploy.sh
+```
+
+It's idempotent (re-runnable) and prints the MCP endpoint at the end. Toggle TLS with
+`ENABLE_TLS=false`. The sections below document each step if you'd rather run them by hand.
+
 ### Prerequisites
 
 - Kubernetes v1.16+ with `kubectl` (±1 minor of the cluster) and `helm` v3.0.2+
@@ -205,9 +220,31 @@ curl --cacert /etc/tls/pulsar-broker/ca.crt -H "Authorization: Bearer <token>" \
 > TLS ports (6651/8443) — neither `certSecretName` nor `config.custom` gets them
 > exposed — so external clients still use plaintext + token via the LB.
 
+### MCP server (snmcp)
+
+The StreamNative MCP server runs **in the `pulsar` namespace** (via `snmcp-values.yaml`)
+so it reaches the cluster over in-cluster DNS:
+
+```bash
+helm install snmcp streamnative/snmcp -n pulsar -f ./pulsar-operators/configs/snmcp-values.yaml
+```
+
+- **Pulsar URL** is pinned to the in-cluster proxy (`…proxy.pulsar.svc.cluster.local:8080/6650`).
+- **Auth = multi-session passthrough:** no token is stored on the server — each caller
+  sends `Authorization: Bearer <pulsar-token>`, which snmcp forwards to Pulsar (so the
+  MCP session inherits exactly what that token authorizes). Use the `client` token for
+  scoped access or a superuser token for admin.
+- Exposed on a **LoadBalancer** (`:9090`) for a LAN MCP client (e.g. Claude Desktop):
+
+```
+MCP endpoint : http://<snmcp-LB-ip>:9090/mcp
+Auth header  : Authorization: Bearer <pulsar token>
+```
+
 ### Cleanup
 
 ```bash
+helm uninstall snmcp -n pulsar                                         # MCP server
 kubectl delete -f ./pulsar-operators/configs/01-pulsar-cluster.yaml   # or 02-pulsar-oxia.yaml
 kubectl delete pvc --all -n pulsar                                     # removes data volumes
 helm uninstall sn-operator -n operators

--- a/pulsar-operators/configs/snmcp-values.yaml
+++ b/pulsar-operators/configs/snmcp-values.yaml
@@ -1,0 +1,27 @@
+# StreamNative MCP Server (snmcp) — values for the local private-cloud lab.
+# Deployed into the `pulsar` namespace alongside the cluster.
+#
+#   helm install snmcp streamnative/snmcp -n pulsar -f snmcp-values.yaml
+#
+# Auth model: snmcp runs in multi-session Pulsar mode — each caller supplies its
+# own `Authorization: Bearer <pulsar-token>` which snmcp forwards to Pulsar. So no
+# token is baked in here; it works with the cluster's JWT auth (use the `client`
+# token for normal ops, a superuser token for admin).
+
+server:
+  readOnly: false
+  httpPath: /mcp
+
+pulsar:
+  # In-cluster proxy (plaintext). Proxy/LB TLS is a separate follow-up; switch to
+  # https://private-cloud-proxy.pulsar.svc.cluster.local:8443 + tls.secretName once
+  # proxy TLS is enabled.
+  webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local:8080
+  serviceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local:6650
+  tls:
+    enabled: false
+
+# Exposed on the LAN via MetalLB so a LAN Claude Desktop/Code client can reach it.
+service:
+  type: LoadBalancer
+  port: 9090

--- a/pulsar-operators/deploy.sh
+++ b/pulsar-operators/deploy.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# One-command deploy of an MCP-enhanced StreamNative Private Cloud (Oxia) cluster:
+#   sn-operator -> license -> JWT auth secrets -> cert-manager/TLS -> Pulsar cluster -> snmcp
+#
+# Usage:
+#   ./deploy.sh
+#
+# microk8s users:
+#   KUBECTL="microk8s kubectl" HELM="microk8s helm3" ./deploy.sh
+#
+# Toggles (env):
+#   ENABLE_TLS=false   # skip cert-manager + broker TLS
+#   CERT_MANAGER_VERSION=v1.16.2
+#
+# Prerequisites: a StreamNative license (configs/00-license-secret.yaml from the
+# template, or an existing `sn-license` secret in `operators`) and `snctl` on PATH
+# (for JWT key/token generation).
+set -euo pipefail
+
+KUBECTL="${KUBECTL:-kubectl}"
+HELM="${HELM:-helm}"
+SNCTL="${SNCTL:-snctl}"
+ENABLE_TLS="${ENABLE_TLS:-true}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.16.2}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIGS="$DIR/configs"
+
+echo "==> [1/8] namespaces"
+for ns in operators pulsar; do
+  $KUBECTL create namespace "$ns" --dry-run=client -o yaml | $KUBECTL apply -f -
+done
+
+echo "==> [2/8] license"
+if [ -f "$CONFIGS/00-license-secret.yaml" ]; then
+  $KUBECTL apply -f "$CONFIGS/00-license-secret.yaml"
+elif $KUBECTL get secret sn-license -n operators >/dev/null 2>&1; then
+  echo "    using existing sn-license secret"
+else
+  echo "ERROR: no license. Create $CONFIGS/00-license-secret.yaml from the .template," >&2
+  echo "       or create a labelled 'sn-license' secret in the operators namespace." >&2
+  exit 1
+fi
+
+echo "==> [3/8] sn-operator (helm)"
+$HELM repo add streamnative https://charts.streamnative.io >/dev/null 2>&1 || true
+$HELM repo update streamnative >/dev/null
+$HELM upgrade --install sn-operator streamnative/sn-operator -n operators --wait
+
+echo "==> [4/8] JWT auth secrets"
+if $KUBECTL get secret token-public-key -n pulsar >/dev/null 2>&1; then
+  echo "    auth secrets already exist — skipping token generation"
+else
+  TMP="$(mktemp -d)"
+  $SNCTL pulsar admin token create-key-pair \
+    --output-private-key "$TMP/token-private.key" --output-public-key "$TMP/token-public.key"
+  for s in broker-admin proxy-admin client; do
+    $SNCTL pulsar admin token create --private-key-file "$TMP/token-private.key" --subject "$s" 2>&1 \
+      | grep -oE 'eyJ[A-Za-z0-9_.-]+' > "$TMP/$s.token"
+  done
+  $KUBECTL create secret generic token-public-key -n pulsar --from-file=my-public.key="$TMP/token-public.key"
+  for s in broker-admin proxy-admin client; do
+    $KUBECTL create secret generic "$s" -n pulsar --from-file=token="$TMP/$s.token"
+  done
+  echo "    tokens generated under $TMP — keep them to configure clients (e.g. the MCP Bearer token)"
+fi
+
+echo "==> [5/8] cert-manager + TLS certs"
+if [ "$ENABLE_TLS" = "true" ]; then
+  $KUBECTL apply -f "https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cert-manager.yaml"
+  $KUBECTL -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+  $KUBECTL apply -f "$CONFIGS/03-pulsar-tls.yaml"
+  $KUBECTL wait --for=condition=Ready certificate/pulsar-server-tls -n pulsar --timeout=120s
+else
+  echo "    ENABLE_TLS=false — skipping (NOTE: 02-pulsar-oxia.yaml references spec.tls; remove it or keep ENABLE_TLS=true)"
+fi
+
+echo "==> [6/8] Pulsar cluster"
+$KUBECTL apply -f "$CONFIGS/02-pulsar-oxia.yaml"
+
+echo "==> [7/8] waiting for the cluster"
+for i in $(seq 1 60); do
+  $KUBECTL get statefulset private-cloud-broker -n pulsar >/dev/null 2>&1 && break
+  sleep 5
+done
+$KUBECTL rollout status statefulset/private-cloud-broker -n pulsar --timeout=600s
+$KUBECTL wait --for=condition=ready pod -l cloud.streamnative.io/component=proxy -n pulsar --timeout=300s || true
+
+echo "==> [8/8] snmcp MCP server (helm)"
+$HELM upgrade --install snmcp streamnative/snmcp -n pulsar -f "$CONFIGS/snmcp-values.yaml" --wait
+
+echo
+echo "================================================================"
+echo " Done. MCP-enhanced Pulsar cluster is up."
+MCP_IP="$($KUBECTL get svc snmcp -n pulsar -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+echo "  MCP endpoint : http://${MCP_IP:-<pending>}:9090/mcp"
+echo "  Auth         : each client sends 'Authorization: Bearer <pulsar-token>'"
+echo "                 (multi-session passthrough — no token stored server-side)"
+echo "================================================================"


### PR DESCRIPTION
Deploys the **StreamNative MCP server (snmcp)** into the `pulsar` namespace and adds a **single-command** deploy script for the full MCP-enhanced stack.

## Changes
- **`configs/snmcp-values.yaml`** — pins the in-cluster proxy URLs (`…proxy.pulsar.svc:8080`/`:6650`), `service.type=LoadBalancer:9090`. Auth is **multi-session passthrough**: no token stored server-side; each caller sends `Authorization: Bearer <pulsar-token>`, which snmcp forwards to Pulsar (the MCP session inherits exactly what that token authorizes).
- **`deploy.sh`** — one command: operator → license → JWT auth secrets → cert-manager/TLS → Oxia cluster → snmcp. Idempotent, prints the MCP endpoint. `KUBECTL`/`HELM` overridable (microk8s), `ENABLE_TLS` toggle.
- **README** — "One-command deploy" + "MCP server (snmcp)" sections; snmcp added to cleanup.

## Verified (live)
- snmcp installed into `pulsar`, pod ready, LoadBalancer `192.168.0.203:9090`, `/mcp/readyz` + `/mcp/healthz` → 200.
- ConfigMap correctly populated: `SNMCP_PULSAR_WEB_SERVICE_URL=http://…proxy…:8080`, `SNMCP_PULSAR_SERVICE_URL=pulsar://…:6650`. No credential baked in (passthrough confirmed).

Pairs with the JWT auth from #17 — Claude Desktop (LAN) connects to `http://<LB-ip>:9090/mcp` with a Pulsar token as the Bearer header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)