### PR TITLE
Add ZooKeeper manifest with package management (jar functions, no MinIO)

### DIFF
--- a/pulsar-operators/README.md
+++ b/pulsar-operators/README.md
@@ -8,10 +8,18 @@ A single `sn-operator` reconciles a `PulsarCoordinator` plus the component CRs
 (`ZooKeeperCluster`/`OxiaCluster`, `BookKeeperCluster`, `PulsarBroker`,
 `PulsarProxy`, `Console`). Pick **one** metadata store:
 
-| Manifest | Metadata store | Operator required |
+| Manifest | Metadata store | Notes |
 | --- | --- | --- |
-| `configs/01-pulsar-cluster.yaml` | ZooKeeper (default) | works on older operators |
-| `configs/02-pulsar-oxia.yaml` | Oxia (no ZooKeeper) | needs a recent `sn-operator` — see note below |
+| `configs/01-pulsar-cluster.yaml` | ZooKeeper | minimal/basic ZK (no auth/TLS) |
+| `configs/02-pulsar-oxia.yaml` | Oxia (no ZooKeeper) | full-featured (JWT auth, TLS, HPA); **no package management** (see below) |
+| `configs/03-pulsar-zookeeper.yaml` | ZooKeeper | full-featured **+ package management / jar functions** |
+
+> **Oxia vs ZooKeeper — package management:** Oxia-backed v2 clusters **do not support
+> function package management** (the BookKeeper package store needs a ZooKeeper
+> DistributedLog namespace; enabling it crashes the broker on Oxia). If you want to
+> upload **jar/nar packages** and run **Function-Mesh jar functions** (no MinIO, no
+> per-function images), use the **ZooKeeper** manifest (`03-pulsar-zookeeper.yaml`).
+> Oxia remains the choice for a ZK-free architecture where packages aren't needed.
 
 ### One-command deploy
 

--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -1,0 +1,235 @@
+# StreamNative Private Cloud — ZooKeeper-backed cluster (full-featured).
+#
+# Chosen over Oxia because Oxia v2 does NOT support function package management
+# (the BookKeeper package store needs ZooKeeper for its DistributedLog namespace).
+# ZK enables jar/nar package management (no MinIO) + Function-Mesh jar functions.
+#
+# Carries the same hardening as the Oxia manifest: JWT auth, broker TLS (cert-manager),
+# broker HPA, required anti-affinity (zk/bookie) + broker topologySpread.
+#
+#   kubectl apply -f ./pulsar-operators/configs/03-pulsar-zookeeper.yaml
+#
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: PulsarCoordinator
+metadata:
+  name: private-cloud
+  namespace: pulsar
+spec:
+  image: streamnative/private-cloud:4.2.1.4
+---
+apiVersion: zookeeper.streamnative.io/v1alpha1
+kind: ZooKeeperCluster
+metadata:
+  name: private-cloud
+  namespace: pulsar
+  labels:
+    k8s.streamnative.io/coordinator-name: private-cloud
+spec:
+  image: streamnative/private-cloud:4.2.1.4
+  replicas: 3
+  pod:
+    resources:
+      requests:
+        cpu: 300m
+        memory: 1Gi
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                cloud.streamnative.io/cluster: private-cloud
+                cloud.streamnative.io/component: zookeeper
+            topologyKey: kubernetes.io/hostname
+    securityContext:
+      runAsNonRoot: true
+  persistence:
+    data:
+      accessModes: [ReadWriteOnce]
+      storageClassName: nvme-raid
+      resources:
+        requests:
+          storage: 8Gi
+    dataLog:
+      accessModes: [ReadWriteOnce]
+      storageClassName: nvme-raid
+      resources:
+        requests:
+          storage: 2Gi
+    reclaimPolicy: Delete
+---
+apiVersion: bookkeeper.streamnative.io/v1alpha1
+kind: BookKeeperCluster
+metadata:
+  name: private-cloud
+  namespace: pulsar
+  labels:
+    k8s.streamnative.io/coordinator-name: private-cloud
+spec:
+  image: streamnative/private-cloud:4.2.1.4
+  replicas: 3
+  zkServers: private-cloud-zk:2181
+  pod:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 4Gi
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                cloud.streamnative.io/cluster: private-cloud
+                cloud.streamnative.io/component: bookie
+            topologyKey: kubernetes.io/hostname
+    securityContext:
+      runAsNonRoot: true
+  storage:
+    journal:
+      numDirsPerVolume: 1
+      numVolumes: 1
+      volumeClaimTemplate:
+        accessModes: [ReadWriteOnce]
+        storageClassName: nvme-raid
+        resources:
+          requests:
+            storage: 30Gi
+    ledger:
+      numDirsPerVolume: 1
+      numVolumes: 1
+      volumeClaimTemplate:
+        accessModes: [ReadWriteOnce]
+        storageClassName: ssd-raid
+        resources:
+          requests:
+            storage: 100Gi
+    reclaimPolicy: Delete
+  autoRecovery:
+    replicas: 1
+    pod:
+      resources:
+        requests:
+          cpu: 200m
+          memory: 512Mi
+---
+apiVersion: pulsar.streamnative.io/v1alpha1
+kind: PulsarBroker
+metadata:
+  name: private-cloud
+  namespace: pulsar
+  annotations:
+    cloud.streamnative.io/enable-config-prefix: "false"
+  labels:
+    k8s.streamnative.io/coordinator-name: private-cloud
+spec:
+  image: streamnative/private-cloud:4.2.1.4
+  replicas: 2
+  zkServers: private-cloud-zk:2181
+  # Operator-managed HPA (CPU 60%, 2-6 replicas).
+  autoScalingPolicy:
+    minReplicas: 2
+    maxReplicas: 6
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 60
+  # Broker TLS (web 8443 + binary pulsar+ssl://6651) via cert-manager.
+  tls:
+    enabled: true
+    certSecretName: pulsar-server-tls
+    trustCertsEnabled: true
+  config:
+    clusterName: private-cloud
+    # Functions run via the Function Mesh operator (CRDs), not the broker's built-in
+    # KubernetesRuntime worker — so the worker stays off. Package management (below)
+    # still serves jar downloads for Function-Mesh `function://` package URLs.
+    function:
+      enabled: false
+    # JWT/token auth internal client identity.
+    clientAuth:
+      jwt:
+        secret: broker-admin
+    custom:
+      # Package management works on ZK (BookKeeper store) — no MinIO.
+      PULSAR_PREFIX_enablePackagesManagement: "true"
+      # --- JWT/token authentication ---
+      PULSAR_PREFIX_authenticationEnabled: "true"
+      PULSAR_PREFIX_authenticateOriginalAuthData: "true"
+      PULSAR_PREFIX_authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderToken
+      PULSAR_PREFIX_authorizationEnabled: "true"
+      PULSAR_PREFIX_authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
+      PULSAR_PREFIX_superUserRoles: broker-admin,proxy-admin
+      PULSAR_PREFIX_proxyRoles: proxy-admin
+      PULSAR_PREFIX_brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+      PULSAR_PREFIX_tokenPublicKey: file:///mnt/secrets/my-public.key
+  pod:
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    secretRefs:
+      - mountPath: /mnt/secrets
+        secretName: token-public-key
+    vars:
+      - name: brokerClientAuthenticationParameters
+        valueFrom:
+          secretKeyRef:
+            name: broker-admin
+            key: token
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            cloud.streamnative.io/cluster: private-cloud
+            cloud.streamnative.io/component: broker
+    securityContext:
+      runAsNonRoot: true
+---
+apiVersion: pulsar.streamnative.io/v1alpha1
+kind: PulsarProxy
+metadata:
+  name: private-cloud
+  namespace: pulsar
+  annotations:
+    cloud.streamnative.io/enable-config-prefix: "false"
+  labels:
+    k8s.streamnative.io/coordinator-name: private-cloud
+spec:
+  image: streamnative/private-cloud:4.2.1.4
+  replicas: 1
+  brokerAddress: private-cloud-broker
+  config:
+    clientAuth:
+      jwt:
+        secret: proxy-admin
+    custom:
+      PULSAR_PREFIX_authenticationEnabled: "true"
+      PULSAR_PREFIX_authenticateOriginalAuthData: "true"
+      PULSAR_PREFIX_forwardAuthorizationCredentials: "true"
+      PULSAR_PREFIX_authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderToken
+      PULSAR_PREFIX_brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+      PULSAR_PREFIX_superUserRoles: proxy-admin
+      PULSAR_PREFIX_tokenPublicKey: file:///mnt/secrets/my-public.key
+  pod:
+    annotations:
+      prometheus.io/port: "8080"
+      prometheus.io/scrape: "true"
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    secretRefs:
+      - mountPath: /mnt/secrets
+        secretName: token-public-key
+    vars:
+      - name: brokerClientAuthenticationParameters
+        valueFrom:
+          secretKeyRef:
+            name: proxy-admin
+            key: token
+    securityContext:
+      runAsNonRoot: true


### PR DESCRIPTION
Oxia v2 **doesn't support function package management** (the BookKeeper package store needs a ZooKeeper DistributedLog namespace — enabling it NPE-crashes the broker on Oxia; [StreamNative docs](https://docs.streamnative.io/private-cloud/v2/configure-private-cloud/components/private-cloud-oxia) confirm it's unsupported). This adds a **full-featured ZooKeeper** manifest so you can run **jar/nar package management + Function-Mesh jar functions — no MinIO, no per-function images**.

## `03-pulsar-zookeeper.yaml`
`ZooKeeperCluster` metadata store + the same hardening as the Oxia manifest:
- **JWT auth** (broker+proxy, superUserRoles, proxyRoles), **broker TLS** (cert-manager, web 8443 + binary `pulsar+ssl://6651`), **broker HPA** (CPU 60%, 2–6), required anti-affinity (zk/bookie) + broker `topologySpreadConstraints`.
- `enablePackagesManagement=true` (BookKeeper store — works on ZK).

## Verified live
- Cluster healthy on ZK; auth enforced (no-token→401, token→200); broker TLS produce over `6651` + admin over `https:8443`.
- **Package management works under auth** — `snctl packages upload`/`list` succeed (this is the exact op that crashed on Oxia).
- A **Function-Mesh function downloads its jar from a `function://` package URL** (correctly gated by the `client` role's `packages` permission).

> Oxia (`02-pulsar-oxia.yaml`) remains valid for a ZK-free architecture where package management isn't needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)