### PR TITLE
deploy.sh -> ZooKeeper default; add FM package-URL function example

### DIFF
--- a/function-mesh-operator/configs/01-package-url-function.yaml
+++ b/function-mesh-operator/configs/01-package-url-function.yaml
@@ -1,0 +1,63 @@
+# Function Mesh function that runs a JAR pulled from Pulsar package management
+# (a `function://` URL) — no docker image build, no MinIO. Requires the ZooKeeper
+# cluster (03-pulsar-zookeeper.yaml) since Oxia doesn't support package management.
+#
+# Prereqs (run once):
+#   1) Upload the jar as a package (any jar; here the broker's bundled examples):
+#        kubectl exec -n pulsar -c pulsar-broker private-cloud-broker-0 -- \
+#          ./bin/pulsar-admin --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+#          --auth-params "token:$ADMIN" packages upload \
+#          function://public/default/exclaim-pkg@v1 --path /pulsar/examples/api-examples.jar
+#   2) Grant the function's role ALL needed actions at once (grant is a SET, not add):
+#        snctl pulsar admin namespaces grant-permission public/default \
+#          --role client --actions produce --actions consume --actions packages
+#   3) Fill in the client token below (from `client.token`; keep it out of git).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pulsar-fn
+  namespace: pulsar
+data:
+  # NOTE the TRAILING DOT on the host — marks the name absolute so the function pod's
+  # resolver doesn't append the search domain (…svc.cluster.local.pulsar.svc.cluster.local).
+  webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local.:8080
+  brokerServiceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local.:6650
+---
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: exclaim-pkg-fn
+  namespace: pulsar
+spec:
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  clusterName: private-cloud
+  forwardSourceMessageProperty: true
+  autoAck: true
+  replicas: 1
+  # Runner image MUST match the cluster's Pulsar version (private-cloud:4.2.1.4 -> Pulsar 4.2.1.4).
+  # A mismatched runner (e.g. 2.9.x) goes Ready but never subscribes.
+  image: streamnative/pulsar-functions-java-runner:4.2.1.4
+  input:
+    topics: [persistent://public/default/pkgfn-input]
+    typeClassName: java.lang.String
+  output:
+    topic: persistent://public/default/pkgfn-output
+    typeClassName: java.lang.String
+  java:
+    jar: api-examples.jar
+    # The jar is DOWNLOADED from package management (needs the role's 'packages' perm):
+    jarLocation: function://public/default/exclaim-pkg@v1
+  pulsar:
+    pulsarConfig: pulsar-fn
+    authConfig:
+      genericAuth:
+        clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
+        clientAuthenticationParameters: token:REPLACE_WITH_CLIENT_TOKEN
+  resources:
+    requests:
+      cpu: "0.1"
+      memory: 1G
+    limits:
+      cpu: "0.2"
+      memory: 1200M

--- a/function-mesh-operator/configs/01-package-url-function.yaml
+++ b/function-mesh-operator/configs/01-package-url-function.yaml
@@ -35,6 +35,11 @@ spec:
   forwardSourceMessageProperty: true
   autoAck: true
   replicas: 1
+  # earliest so the function reads from the start once subscribed. IMPORTANT: let the
+  # function create its consumer FIRST (it sets the topic's STRING schema). If you
+  # `pulsar-client produce` to the input topic before the function subscribes, the topic
+  # gets a BYTES schema and the function fails with IncompatibleSchemaException.
+  subscriptionPosition: earliest
   # Runner image MUST match the cluster's Pulsar version (private-cloud:4.2.1.4 -> Pulsar 4.2.1.4).
   # A mismatched runner (e.g. 2.9.x) goes Ready but never subscribes.
   image: streamnative/pulsar-functions-java-runner:4.2.1.4

--- a/pulsar-operators/deploy.sh
+++ b/pulsar-operators/deploy.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
-# One-command deploy of an MCP-enhanced StreamNative Private Cloud (Oxia) cluster:
+# One-command deploy of an MCP-enhanced StreamNative Private Cloud cluster:
 #   sn-operator -> license -> JWT auth secrets -> cert-manager/TLS -> Pulsar cluster -> snmcp
+#
+# Defaults to the ZooKeeper manifest (03-pulsar-zookeeper.yaml) because it supports
+# package management + Function-Mesh jar functions. Use CLUSTER_MANIFEST to switch to
+# Oxia (02-pulsar-oxia.yaml) for a ZK-free cluster (no package management).
 #
 # Usage:
 #   ./deploy.sh
@@ -10,7 +14,8 @@
 #   KUBECTL="microk8s kubectl" HELM="microk8s helm3" ./deploy.sh
 #
 # Toggles (env):
-#   ENABLE_TLS=false   # skip cert-manager + broker TLS
+#   CLUSTER_MANIFEST=02-pulsar-oxia.yaml   # default: 03-pulsar-zookeeper.yaml
+#   ENABLE_TLS=false                       # skip cert-manager + broker TLS
 #   CERT_MANAGER_VERSION=v1.16.2
 #
 # Prerequisites: a StreamNative license (configs/00-license-secret.yaml from the
@@ -23,6 +28,7 @@ HELM="${HELM:-helm}"
 SNCTL="${SNCTL:-snctl}"
 ENABLE_TLS="${ENABLE_TLS:-true}"
 CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.16.2}"
+CLUSTER_MANIFEST="${CLUSTER_MANIFEST:-03-pulsar-zookeeper.yaml}"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIGS="$DIR/configs"
@@ -76,8 +82,8 @@ else
   echo "    ENABLE_TLS=false — skipping (NOTE: 02-pulsar-oxia.yaml references spec.tls; remove it or keep ENABLE_TLS=true)"
 fi
 
-echo "==> [6/8] Pulsar cluster"
-$KUBECTL apply -f "$CONFIGS/02-pulsar-oxia.yaml"
+echo "==> [6/8] Pulsar cluster ($CLUSTER_MANIFEST)"
+$KUBECTL apply -f "$CONFIGS/$CLUSTER_MANIFEST"
 
 echo "==> [7/8] waiting for the cluster"
 for i in $(seq 1 60); do


### PR DESCRIPTION
Follow-up to the ZooKeeper pivot (#19).

- **`deploy.sh`** now defaults to the **ZooKeeper** manifest (`03-pulsar-zookeeper.yaml`) since it supports package management + jar functions; `CLUSTER_MANIFEST=02-pulsar-oxia.yaml` switches to the ZK-free Oxia cluster.
- **`function-mesh-operator/configs/01-package-url-function.yaml`** — a Function Mesh function that **pulls its jar from a `function://` package URL** (no docker image, no MinIO). Documents the gotchas found live:
  - **Runner image must match the cluster's Pulsar version** (`pulsar-functions-java-runner:4.2.1.4`) — a mismatch goes Ready but never subscribes.
  - **Trailing-dot FQDN** in the connection ConfigMap — avoids the function pod's resolver appending the search domain (`…svc.cluster.local.pulsar.svc.cluster.local`).
  - **`grant-permission` is a set, not add** — grant `produce,consume,packages` together; the `packages` perm is what authorizes the `function://` download.

The download + auth mechanism is proven (the function correctly fails without the `packages` perm and downloads with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)