### PR TITLE
Enable Orca / Function Mesh Worker Service (functions create --jar)

### DIFF
--- a/pulsar-operators/README.md
+++ b/pulsar-operators/README.md
@@ -249,6 +249,31 @@ MCP endpoint : http://<snmcp-LB-ip>:9090/mcp
 Auth header  : Authorization: Bearer <pulsar token>
 ```
 
+### Functions: `functions create --jar` via Orca (Function Mesh Worker Service)
+
+`03-pulsar-zookeeper.yaml` enables **Orca / FMWS** on the broker — the bundled
+`mesh-worker-service.nar` turns the functions-worker into a translator, so the familiar
+CLI workflow creates **Function Mesh `Function` CRDs** (jar in package management, stock
+runner image, no hand-written CRDs). The operator's `function.mesh` field alone doesn't
+wire the NAR — it's injected via `config.function.customWorkerConfig` (`functionsWorkerServiceNarPackage`
++ `functionsWorkerServiceCustomConfigs` with `functionRunnerImages`).
+
+```bash
+# (token required since auth is on; the broker's bundled examples jar):
+kubectl exec -n pulsar -c pulsar-broker private-cloud-broker-0 -- \
+  ./bin/pulsar-admin --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
+  --auth-params "token:$ADMIN" functions create \
+  --tenant public --namespace default --name myfn \
+  --className org.apache.pulsar.functions.api.examples.ExclamationFunction \
+  --inputs persistent://public/default/in --output persistent://public/default/out \
+  --jar /pulsar/examples/api-examples.jar
+# -> a `Function` CRD appears (kubectl get function -n pulsar); FMWS auto-propagates the
+#    caller's token into the function and uses the configured runner image.
+```
+
+For full control you can still apply a `Function` CRD directly — see
+`function-mesh-operator/configs/01-package-url-function.yaml` (with its gotchas).
+
 ### Cleanup
 
 ```bash

--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -142,11 +142,25 @@ spec:
     trustCertsEnabled: true
   config:
     clusterName: private-cloud
-    # Functions run via the Function Mesh operator (CRDs), not the broker's built-in
-    # KubernetesRuntime worker — so the worker stays off. Package management (below)
-    # still serves jar downloads for Function-Mesh `function://` package URLs.
+    # Orca / Function Mesh Worker Service (FMWS): the bundled mesh-worker-service NAR
+    # turns the broker's functions-worker into a translator — `pulsar-admin/snctl
+    # functions create --jar` becomes a Function Mesh `Function` CRD (no hand-written
+    # CRDs, no per-function image build; jar lives in package management). The operator's
+    # `function.mesh` field alone does NOT wire the NAR — inject it via customWorkerConfig.
+    # FMWS auto-propagates the caller's auth token into each function it creates.
     function:
-      enabled: false
+      enabled: true
+      customWorkerConfig: |
+        functionsWorkerServiceNarPackage: /pulsar/lib/mesh-worker-service.nar
+        functionsWorkerServiceCustomConfigs:
+          uploadEnabled: true
+          functionEnabled: true
+          sinkEnabled: true
+          sourceEnabled: true
+          functionRunnerImages:
+            JAVA: streamnative/pulsar-functions-java-runner:4.2.1.4
+            PYTHON: streamnative/pulsar-functions-python-runner:4.2.1.4
+            GO: streamnative/pulsar-functions-go-runner:4.2.1.4
     # JWT/token auth internal client identity.
     clientAuth:
       jwt:


### PR DESCRIPTION
Adds **Orca / FMWS** to the ZooKeeper broker so the familiar `pulsar-admin/snctl functions create --jar` workflow works — translated into Function Mesh `Function` CRDs (jar pulled from package management, stock runner image; no hand-written CRDs, no per-function image build).

## How
The bundled `mesh-worker-service.nar` is in the image but the operator's `config.function.mesh` field doesn't wire it (worker stays on `KubernetesRuntimeFactory`). Per the StreamNative deploy-orca docs, it's enabled via `config.function.customWorkerConfig`:
- `functionsWorkerServiceNarPackage: /pulsar/lib/mesh-worker-service.nar`
- `functionsWorkerServiceCustomConfigs` (upload/function/sink/source enabled + `functionRunnerImages` pinned to `4.2.1.4`)

## Verified live (under JWT auth, on ZK)
- `functions create --jar` → a `Function` CRD appears (`kubectl get function -n pulsar`), **not** a KubernetesRuntime pod.
- The function runs and processes: produce `hello` → consume **`hello!`**.
- FMWS **auto-propagates the caller's token** into the function's `authConfig` and uses the configured runner image — so the auth wiring is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)