### PR TITLE
Enable Kafka protocol (KoP) on the broker

### DIFF
--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -161,6 +161,19 @@ spec:
             JAVA: streamnative/pulsar-functions-java-runner:4.2.1.4
             PYTHON: streamnative/pulsar-functions-python-runner:4.2.1.4
             GO: streamnative/pulsar-functions-go-runner:4.2.1.4
+    # Kafka protocol (KoP) — Kafka clients talk to the broker on :9092.
+    # SASL_PLAINTEXT + SASL/PLAIN: clients pass password "token:<jwt>" (the existing
+    # JWT auth provider validates it). A Kafka topic `t` maps to public/default/t.
+    # NOTE: proxy-side KoP (`PulsarProxy.config.kopProxy`) is NOT usable on the
+    # private-cloud:4.2.1.4 image — the Kafka proxy-extension NAR isn't shipped
+    # (/pulsar/proxyextensions is absent; the KoP NAR registers only a broker
+    # ProtocolHandler, not a ProxyExtension), so enabling kopProxy crashloops the
+    # proxy. Kafka clients connect to the broker directly (in-cluster, or a broker
+    # LoadBalancer with per-broker advertised listeners for external access).
+    protocolHandlers:
+      kop:
+        enabled: true
+        saslAllowedMechanisms: [PLAIN]
     # JWT/token auth internal client identity.
     clientAuth:
       jwt:


### PR DESCRIPTION
Enables **Kafka-on-Pulsar (KoP)** so Kafka clients can talk to the cluster.

## Broker (works ✅)
`config.protocolHandlers.kop` = `{enabled: true, saslAllowedMechanisms: [PLAIN]}`. The operator renders `messagingProtocols=kafka`, `kafkaListeners=SASL_PLAINTEXT://0.0.0.0:9092`, and exposes 9092 (+ schema registry 8001) on the broker service.

**Auth:** clients use SASL_PLAINTEXT + SASL/PLAIN with `password="token:<jwt>"` — validated by the existing JWT auth provider. A Kafka topic `t` maps to `persistent://public/default/t`.

**Verified live:** `kafka-console-producer/consumer` (Kafka 3.9) produced + consumed `hello-kafka` under SASL token auth; cross-checked that it landed as a Pulsar topic.

## Proxy (not possible on this image ⚠️)
`PulsarProxy.config.kopProxy` exists in the CRD, but the **Kafka proxy-extension NAR is not shipped** in `private-cloud:4.2.1.4`:
- `/pulsar/proxyextensions` doesn't exist; the bundled KoP NAR registers only a broker `ProtocolHandler`, not a `ProxyExtension`.
- Enabling `kopProxy` sets `proxyExtensions=kafka` → `No extension is found for extension name kafka` → proxy crashloops.

So Kafka clients connect to the **broker directly** (in-cluster, or a broker LoadBalancer with per-broker advertised listeners for external access). Documented inline in the manifest. Same class of gap as the proxy-TLS limitation in this operator/image version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)