### PR TITLE
External Kafka (KSN) via Istio gateway + ServiceEntry workaround

### DIFF
--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -140,8 +140,47 @@ spec:
     enabled: true
     certSecretName: pulsar-server-tls
     trustCertsEnabled: true
+  # External Kafka (KSN) via the Istio ingress gateway (TLS PASSTHROUGH, per-broker SNI).
+  # Clients reach broker-N.kafka.lab:9093 (SASL_SSL+token); the gateway SNI-routes to the
+  # broker's external KSN listener on :9095 which terminates TLS with kafka-broker-tls.
+  # REQUIRES the per-pod ServiceEntries in 04-ksn-istio-gateway.yaml — the operator does NOT
+  # generate them for advertisedListeners[].istioGateway (see docs/ksn-istio-gateway-bug-report.md).
+  # hostTemplate uses $(POD_NAME) (NOT $(POD_ID), which isn't a broker env var); containerPort
+  # 9095 is distinct from the internal KSN 9092; pulsar protocol disabled to avoid a 6651 double-bind.
+  advertisedListeners:
+    - name: external
+      hostTemplate: "$(POD_NAME).kafka.lab"
+      protocols:
+        pulsar:
+          enabled: false
+        kafka:
+          enabled: true
+          scheme: SASL_SSL
+          advertisedPort: 9093
+          containerPort: 9095
+      istioGateway:
+        clusterAddress: kafka.lab
+        selector:
+          istio: ingressgateway
+        tls:
+          mode: PASSTHROUGH
   config:
     clusterName: private-cloud
+    # Kafka protocol (KSN). Internal clients use SASL_PLAINTEXT on :9092; the external
+    # listener (above) uses SASL_SSL on :9095. SASL/PLAIN auth: password "token:<jwt>".
+    # kop.tls gives the external listener a JKS keystore (KSN needs JKS, not PEM).
+    protocolHandlers:
+      kop:
+        enabled: true
+        saslAllowedMechanisms: [PLAIN]
+        tls:
+          enabled: true
+          certSecretName: kafka-broker-tls
+          trustCertsEnabled: true
+          clientAuth: none
+          passwordSecretRef:
+            name: kafka-keystore-pass
+            key: password
     # Orca / Function Mesh Worker Service (FMWS): the bundled mesh-worker-service NAR
     # turns the broker's functions-worker into a translator — `pulsar-admin/snctl
     # functions create --jar` becomes a Function Mesh `Function` CRD (no hand-written

--- a/pulsar-operators/configs/04-ksn-istio-gateway.yaml
+++ b/pulsar-operators/configs/04-ksn-istio-gateway.yaml
@@ -1,0 +1,75 @@
+# External Kafka (KSN) via the Istio ingress gateway — supporting resources.
+# Companion to the broker `advertisedListeners[].istioGateway` + `protocolHandlers.kop.tls`
+# config in 03-pulsar-zookeeper.yaml. See docs/ksn-istio-gateway.md (runbook) and
+# docs/ksn-istio-gateway-bug-report.md (the operator ServiceEntry gap this works around).
+#
+# PREREQUISITES (not expressible as CRs here):
+#   1) Istio 1.24.2+ (operator emits networking.istio.io/v1):
+#        istioctl install --set profile=default
+#   2) Expose the Kafka port on the ingress gateway service (the install doesn't):
+#        kubectl patch svc istio-ingressgateway -n istio-system --type=json \
+#          -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"kafka-tls","port":9093,"targetPort":9093,"protocol":"TCP"}}]'
+#   3) JKS keystore password secret referenced by the cert + kop.tls (keep out of git):
+#        kubectl create secret generic kafka-keystore-pass -n pulsar --from-literal=password='<choose-one>'
+#   4) Client DNS: kafka.lab + *.kafka.lab -> the istio-ingressgateway LB IP
+#        (in-cluster dnsmasq, or /etc/hosts / hostAliases on the client).
+#   5) After installing Istio while the operator is already running, restart it so it
+#      re-detects the Istio CRDs:  kubectl rollout restart deploy/sn-operator -n operators
+---
+# Broker-side cert for the external KSN listener (TLS PASSTHROUGH = broker terminates TLS).
+# keystores.jks makes cert-manager emit keystore.jks (KSN needs JKS at /etc/tls/pulsar-kop/).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kafka-broker-tls
+  namespace: pulsar
+spec:
+  secretName: kafka-broker-tls
+  issuerRef:
+    name: pulsar-ca-issuer      # the CA issuer from 03-pulsar-tls.yaml
+    kind: Issuer
+  commonName: kafka.lab
+  dnsNames:
+    - kafka.lab
+    - "*.kafka.lab"
+  keystores:
+    jks:
+      create: true
+      passwordSecretRef:
+        name: kafka-keystore-pass
+        key: password
+---
+# THE GAP FIX: per-pod ServiceEntries. The operator generates per-pod Gateway+VirtualService
+# from advertisedListeners[].istioGateway but NOT the matching ServiceEntry, so the ingress
+# gateway has no routable cluster for the per-pod headless DNS. One per broker replica.
+# NOTE: broker HPA is min2/max6 — scaling past 2 needs broker-2..broker-5 entries too (until
+# the operator auto-generates these; see the bug report).
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: broker-0-kafka-ext
+  namespace: pulsar
+spec:
+  hosts:
+    - private-cloud-broker-0.private-cloud-broker-headless.pulsar.svc.cluster.local
+  location: MESH_INTERNAL
+  ports:
+    - number: 9095
+      name: tcp-kafka-ext
+      protocol: TCP
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: broker-1-kafka-ext
+  namespace: pulsar
+spec:
+  hosts:
+    - private-cloud-broker-1.private-cloud-broker-headless.pulsar.svc.cluster.local
+  location: MESH_INTERNAL
+  ports:
+    - number: 9095
+      name: tcp-kafka-ext
+      protocol: TCP
+  resolution: DNS

--- a/pulsar-operators/docs/ksn-istio-gateway-bug-report.md
+++ b/pulsar-operators/docs/ksn-istio-gateway-bug-report.md
@@ -1,0 +1,136 @@
+# [BUG] advertisedListeners[].istioGateway does not generate per-pod ServiceEntries → external Kafka (KSN) per-broker routing fails
+
+## Summary
+
+When exposing Kafka (KSN) externally via `PulsarBroker.spec.advertisedListeners[].istioGateway`, the
+operator generates the per-pod **Gateway** and **VirtualService** resources but **does not generate
+the per-pod `ServiceEntry`**. The generated VirtualServices route to per-pod headless DNS
+(`<broker>-N.<broker>-headless.<ns>.svc.cluster.local:<containerPort>`), which Istio does not have in
+its service registry, so the ingress gateway builds an empty cluster and omits the listener
+(`must have more than 0 chains`). Kafka clients can bootstrap against the cluster address but cannot
+reach individual brokers (`SSL handshake failed` / `terminated during authentication`), so
+produce/consume time out.
+
+The older `spec.istio.gateways[]` code path **does** generate per-pod ServiceEntries
+(`MakeDesiredIstioServiceEntryForPod`, `controllers/pulsar/spec/istio.go`, wired via
+`serviceEntryReconciler`). The advertised-listener path
+(`controllers/pulsar/spec/istio_advertised_listeners.go`) wires only Gateway + VirtualService
+reconcilers and omits the ServiceEntry reconciler. This asymmetry is the bug.
+
+## Affected versions
+
+- sn-operator: **v0.18.14**
+- image: **streamnative/private-cloud:4.2.1.4** (KSN 4.2.1.4)
+- Istio: **1.24.3**
+- metadata store: ZooKeeper; auth: JWT/token; broker TLS via cert-manager
+
+## Steps to reproduce
+
+1. Cluster with KSN enabled (`config.protocolHandlers.kop.enabled: true`) and a JKS keystore for the
+   external Kafka listener (`config.protocolHandlers.kop.tls`).
+2. Install Istio 1.24.x; add port 9093 to the `istio-ingressgateway` Service.
+3. Configure an advertised listener with an Istio gateway (TLS PASSTHROUGH):
+
+   ```yaml
+   spec:
+     advertisedListeners:
+       - name: external
+         hostTemplate: "$(POD_NAME).kafka.lab"
+         protocols:
+           pulsar: { enabled: false }
+           kafka:  { enabled: true, scheme: SASL_SSL, advertisedPort: 9093, containerPort: 9095 }
+         istioGateway:
+           clusterAddress: kafka.lab
+           selector: { istio: ingressgateway }
+           tls: { mode: PASSTHROUGH }
+   ```
+
+4. Point `kafka.lab` and `*.kafka.lab` at the ingress gateway LB IP and run a Kafka client
+   (`security.protocol=SASL_SSL`, SASL/PLAIN token, PEM truststore of the cluster CA):
+
+   ```bash
+   kafka-console-producer.sh --bootstrap-server kafka.lab:9093 --producer.config c.properties --topic t
+   ```
+
+## Expected behavior
+
+The operator generates everything needed for external per-broker access (Gateway + VirtualService +
+**ServiceEntry**), and Kafka clients can produce/consume against individual brokers — the same way
+`spec.istio.gateways[]` works.
+
+## Actual behavior
+
+Per-broker connections fail; produce/consume time out. The ingress gateway never programs the Kafka
+listener because the per-pod destination clusters have no endpoints.
+
+## Evidence
+
+istiod:
+```
+gateway pulsar/private-cloud-external-private-cloud-broker-0:9093 listener missed network filter
+gateway omitting listener "0.0.0.0_9093" due to: must have more than 0 chains in listener "0.0.0.0_9093"
+```
+
+`istioctl analyze -n pulsar`:
+```
+Error [IST0101] (VirtualService private-cloud-external-private-cloud-broker-0)
+  Referenced host not found: "private-cloud-broker-0.private-cloud-broker-headless.pulsar.svc.cluster.local"
+```
+
+`istioctl proxy-config endpoints deploy/istio-ingressgateway -n istio-system` — no endpoints for the
+per-pod `outbound|9095||private-cloud-broker-0.private-cloud-broker-headless...` cluster.
+
+Kafka client:
+```
+Connection to node ... (private-cloud-broker-0.kafka.lab/<gw-ip>:9093) terminated during authentication
+... failed authentication due to: SSL handshake failed
+TimeoutException: Topic t not present in metadata after 60000 ms
+```
+
+## Root cause
+
+The per-pod VirtualService destination (per-pod headless DNS) is not registered in Istio's service
+registry, so its cluster has no endpoints and the TLS-PASSTHROUGH listener is dropped. The
+`spec.istio.gateways[]` path registers it via a per-pod ServiceEntry; the advertised-listener path
+does not.
+
+## Proposed fix
+
+Generate per-pod `ServiceEntry` resources in the advertised-listener Istio path (mirroring
+`MakeDesiredIstioServiceEntryForPod`), and reconcile them on broker scale up/down. Each ServiceEntry
+should register the per-pod host + the listener's container port, e.g.:
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata: { name: <broker>-<listener>-<pod>, namespace: <ns> }
+spec:
+  hosts: ["<broker>-N.<broker>-headless.<ns>.svc.cluster.local"]
+  location: MESH_INTERNAL
+  ports: [{ number: <containerPort>, name: tcp-<listener>, protocol: TCP }]
+  resolution: DNS   # or STATIC with the pod IP
+```
+
+## Workaround
+
+Manually create one ServiceEntry per broker pod (as above). After applying, the per-pod clusters
+report `HEALTHY` endpoints, the 9093 listener is programmed, and produce/consume succeed.
+
+**Note:** Do **not** enable `spec.istio` (sidecar mesh) to work around this — meshing the brokers
+creates `ISTIO_MUTUAL` DestinationRules, which make the gateway attempt Istio-mTLS to the broker
+instead of TLS PASSTHROUGH, causing `SSL handshake failed`. The ServiceEntry workaround does not
+require the brokers to be on the mesh.
+
+## Additional gotchas observed (may warrant doc fixes)
+
+- `hostTemplate` must use `$(POD_NAME)`; `$(POD_ID)` is not a broker env var and yields a literal
+  string → KSN `Listener '...' is invalid` crash.
+- The external Kafka listener needs a **distinct** containerPort; reusing the internal `9092`
+  double-binds and crashes the broker. An external listener with `protocols.pulsar` enabled
+  double-binds `6651`.
+- The operator caches "Istio not installed" — installing Istio after the operator is running
+  requires an operator restart before any Gateway/VirtualService is generated.
+- `tls.mode: SIMPLE` emits SNI-match routes that cannot match after TLS termination for a TCP
+  service → `listener missed network filter / 0 chains`. PASSTHROUGH is required for Kafka.
+- KSN requires a JKS keystore at `/etc/tls/pulsar-kop/keystore.jks`; a PEM-only secret yields
+  `KeyStore Path not accessible`.

--- a/pulsar-operators/docs/ksn-istio-gateway.md
+++ b/pulsar-operators/docs/ksn-istio-gateway.md
@@ -1,0 +1,164 @@
+# KSN (Kafka) external access via Istio ingress gateway — operator gap + working configuration
+
+**Status:** Reproduced + worked around. End-to-end Kafka produce/consume through the Istio
+ingress gateway is **working** with the workaround below.
+
+## TL;DR (the bug)
+
+`PulsarBroker.spec.advertisedListeners[].istioGateway` generates the per-pod **Gateway** and
+**VirtualService**, but **does not generate the per-pod `ServiceEntry`**. The VirtualServices route
+to per-pod headless DNS (`<broker>-N.<broker>-headless.<ns>.svc.cluster.local:<containerPort>`),
+which Istio does not register as a routable host on its own — so the ingress gateway ends up with an
+**empty cluster / `0 chains`** and external Kafka clients cannot reach individual brokers.
+
+The older `spec.istio.gateways[]` code path **does** generate per-pod ServiceEntries
+(`MakeDesiredIstioServiceEntryForPod`, `controllers/pulsar/spec/istio.go:177-375`, wired via
+`serviceEntryReconciler` in the broker `IstioReconciler`). The newer advertised-listener path
+(`controllers/pulsar/spec/istio_advertised_listeners.go`) only wires
+`makeAdvListenerGatewayReconciler` + `makeAdvListenerVirtualServiceReconciler` — **no ServiceEntry
+reconciler**. That asymmetry is the gap.
+
+**Fix request:** the advertised-listener path should generate per-pod ServiceEntries the same way
+`spec.istio.gateways[]` does (and keep them reconciled on scale up/down).
+
+## Environment
+
+| | |
+|---|---|
+| sn-operator | `v0.18.14` |
+| image | `streamnative/private-cloud:4.2.1.4` (KSN 4.2.1.4) |
+| Istio | `1.24.3` (`istioctl install --set profile=default`) |
+| metadata store | ZooKeeper |
+| auth | JWT/token (`AuthenticationProviderToken`), broker TLS via cert-manager |
+
+## Symptoms
+
+With only `spec.advertisedListeners[].istioGateway` configured (PASSTHROUGH), the operator creates
+the Gateways + VirtualServices, but:
+
+```
+# istiod
+gateway pulsar/private-cloud-external-cluster:9093 listener missed network filter
+gateway omitting listener "0.0.0.0_9093" due to: must have more than 0 chains in listener "0.0.0.0_9093"
+
+# istioctl analyze -n pulsar
+Error [IST0101] (VirtualService private-cloud-external-private-cloud-broker-0)
+  Referenced host not found: "private-cloud-broker-0.private-cloud-broker-headless.pulsar.svc.cluster.local"
+
+# istioctl proxy-config endpoints deploy/istio-ingressgateway -n istio-system
+# (no endpoints for the per-pod outbound|9095||...broker-0...headless... cluster)
+```
+
+Kafka clients bootstrap OK against the cluster address but then fail per-broker with
+`Connection ... terminated during authentication` / `SSL handshake failed`, and produce/consume
+time out.
+
+## Root cause
+
+`outbound|<port>||<pod>.<headless-svc>...` clusters have **no endpoints** because Istio has no
+service-registry entry for the per-pod headless hostname referenced by the VirtualService. The
+`spec.istio.gateways[]` path solves this with a per-pod ServiceEntry; the advertised-listener path
+omits it.
+
+## Workaround — per-pod ServiceEntry (the missing resource)
+
+One per broker pod (`resolution: DNS` lets Envoy resolve the headless pod DNS to the pod IP, so it
+survives pod IP changes; `STATIC` with the pod IP also works, matching what the operator generates):
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: broker-0-kafka-ext
+  namespace: pulsar
+spec:
+  hosts: ["private-cloud-broker-0.private-cloud-broker-headless.pulsar.svc.cluster.local"]
+  location: MESH_INTERNAL
+  ports:
+    - { number: 9095, name: tcp-kafka-ext, protocol: TCP }
+  resolution: DNS
+```
+
+After applying, the per-pod cluster reports `HEALTHY` endpoints and the `9093` listener is
+programmed.
+
+> **Do NOT enable `spec.istio` (mesh/sidecars) to "fix" this.** Meshing the brokers creates
+> `ISTIO_MUTUAL` DestinationRules, so the gateway attempts Istio-mTLS to the broker instead of TLS
+> **PASSTHROUGH** → `SSL handshake failed`. The ServiceEntry does not require the brokers to be on
+> the mesh.
+
+## Full working configuration
+
+1. **Istio 1.24.3** (operator emits `networking.istio.io/v1`; older Istio that only serves
+   `v1beta1`/`v1alpha3` rejects it). Add the Kafka port to the ingress Service:
+   ```bash
+   kubectl patch svc istio-ingressgateway -n istio-system --type=json \
+     -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"kafka-tls","port":9093,"targetPort":9093,"protocol":"TCP"}}]'
+   ```
+
+2. **TLS for the broker's external KSN listener** — KSN needs a **JKS keystore** at
+   `/etc/tls/pulsar-kop/keystore.jks` (a PEM-only secret yields `KeyStore Path not accessible`).
+   cert-manager can emit one:
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: Certificate
+   metadata: { name: kafka-broker-tls, namespace: pulsar }
+   spec:
+     secretName: kafka-broker-tls
+     issuerRef: { name: pulsar-ca-issuer, kind: Issuer }
+     commonName: kafka.lab
+     dnsNames: ["kafka.lab", "*.kafka.lab"]
+     keystores:
+       jks:
+         create: true
+         passwordSecretRef: { name: kafka-keystore-pass, key: password }
+   ```
+
+3. **PulsarBroker** (TLS PASSTHROUGH; broker terminates TLS):
+   ```yaml
+   spec:
+     config:
+       protocolHandlers:
+         kop:
+           enabled: true
+           saslAllowedMechanisms: [PLAIN]
+           tls:
+             enabled: true
+             certSecretName: kafka-broker-tls
+             trustCertsEnabled: true
+             clientAuth: none
+             passwordSecretRef: { name: kafka-keystore-pass, key: password }
+     advertisedListeners:
+       - name: external
+         hostTemplate: "$(POD_NAME).kafka.lab"        # $(POD_ID) is NOT a broker env var
+         protocols:
+           pulsar: { enabled: false }                 # else an external pulsar listener double-binds 6651
+           kafka:  { enabled: true, scheme: SASL_SSL, advertisedPort: 9093, containerPort: 9095 }
+         istioGateway:
+           clusterAddress: kafka.lab
+           selector: { istio: ingressgateway }
+           tls: { mode: PASSTHROUGH }
+   ```
+
+4. **Per-pod ServiceEntries** (the workaround above), one per replica.
+
+5. **Client DNS:** `kafka.lab` and `*.kafka.lab` → ingress gateway LB IP. Kafka client config:
+   ```properties
+   security.protocol=SASL_SSL
+   sasl.mechanism=PLAIN
+   sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="public/default" password="token:<jwt>";
+   ssl.truststore.type=PEM
+   ssl.truststore.location=/path/to/ca.crt
+   ```
+
+## Gotchas encountered (all real)
+
+| Symptom | Cause / fix |
+|---|---|
+| KSN `Listener '...$(POD_ID)...' is invalid` crash | use `$(POD_NAME)` in `hostTemplate` (POD_ID isn't a broker env var) |
+| Broker crashloop, double-bind `:9092` / `:6651` | external Kafka needs a **distinct** containerPort (9095); `protocols.pulsar.enabled: false` |
+| No Gateway/VirtualService generated at all | operator cached "Istio not installed"; **restart sn-operator** after installing Istio |
+| `listener missed network filter / 0 chains` | `tls.mode: SIMPLE` emits SNI routes that can't match after termination — use **PASSTHROUGH** for TCP/Kafka |
+| `KeyStore Path not accessible: .../keystore.jks` | KSN needs JKS; add `keystores.jks` to the cert-manager Certificate + `kop.tls.passwordSecretRef` |
+| `Referenced host not found` / empty per-pod endpoints | **the gap** — add per-pod ServiceEntries |
+| `SSL handshake failed` per-broker | don't mesh the brokers; `ISTIO_MUTUAL` DestinationRules break PASSTHROUGH |


### PR DESCRIPTION
Exposes **Kafka (KSN) externally through the Istio ingress gateway** — the StreamNative-supported alternative to the (dead-end) Pulsar `kopProxy`. Verified end-to-end: produce + consume via `kafka.lab:9093` (SASL_SSL + token), routed to individual brokers.

## What's here
- **`03-pulsar-zookeeper.yaml`** — broker `spec.advertisedListeners[].istioGateway` (TLS PASSTHROUGH) + `config.protocolHandlers.kop` incl. `kop.tls` (JKS keystore). Internal KSN stays on `:9092`; external is `:9095`, advertised as `broker-N.kafka.lab:9093`.
- **`04-ksn-istio-gateway.yaml`** — the `kafka-broker-tls` cert (cert-manager JKS keystore) + the **per-pod ServiceEntries** + prerequisite steps (Istio install, the `9093` ingress-gateway port, the keystore-password secret, client DNS).
- **`docs/ksn-istio-gateway.md`** — runbook (full config + every gotcha hit).
- **`docs/ksn-istio-gateway-bug-report.md`** — ticket-ready report of the root cause.

## The operator gap (root cause)
`advertisedListeners[].istioGateway` generates per-pod **Gateway + VirtualService** but **not** the per-pod **ServiceEntry** — while the older `spec.istio.gateways[]` path *does* (`MakeDesiredIstioServiceEntryForPod`). Without the ServiceEntry the ingress gateway has no routable cluster for the per-pod headless destination → `istioctl analyze`: "Referenced host not found" → clients can't reach individual brokers. The ServiceEntries in `04-…` are the workaround.

## Notes
- **Don't mesh the brokers** to "fix" routing — `ISTIO_MUTUAL` DestinationRules break PASSTHROUGH (`SSL handshake failed`). The ServiceEntry needs no mesh.
- HPA is min2/max6; scaling past 2 needs `broker-2..5` ServiceEntries until the operator auto-generates them.
- **Supersedes #22** (includes its `protocolHandlers.kop` enablement) — close #22 in favor of this, or merge this instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)