### PR TITLE
kafka-dnsmasq: HA + LAN host records

### DIFF
--- a/pulsar-operators/configs/05-kafka-dns.yaml
+++ b/pulsar-operators/configs/05-kafka-dns.yaml
@@ -1,7 +1,8 @@
-# In-cluster dnsmasq that resolves the Kafka domain for external clients with no DNS server
-# of their own. Wildcards *.kafka.lab + kafka.lab to the Istio ingress gateway LB IP, and
-# forwards everything else upstream. Point your Kafka client machine's resolver at this
-# Service's LoadBalancer IP (no router conditional-forwarder needed).
+# In-cluster dnsmasq that resolves the Kafka domain (and a few LAN infra names) for clients
+# with no DNS server of their own. Wildcards *.kafka.lab + kafka.lab to the Istio ingress
+# gateway LB IP, serves k8s-node/etcd host records, and forwards everything else upstream.
+# Point your client machine's resolver at this Service's LoadBalancer IP (192.168.0.206)
+# (no router conditional-forwarder needed).
 #
 # Companion to 03/04-* (external Kafka via the Istio gateway).
 # IMPORTANT: set the gateway IP in the ConfigMap below to your istio-ingressgateway LB IP.
@@ -19,6 +20,13 @@ data:
     server=1.1.1.1
     # *.kafka.lab and kafka.lab -> the Istio ingress gateway LB IP
     address=/kafka.lab/192.168.0.205
+    # LAN infrastructure records (mirror of the manual /etc/hosts on each node):
+    # k8s node + etcd hostnames so clients using this resolver don't need their own
+    # /etc/hosts entries. host-record gives forward A + reverse PTR; multiple names
+    # per IP are allowed. Keep in sync with node InternalIPs.
+    host-record=k8s-node00.kubernetes.net,k8s-node00,etcd-node00,192.168.0.80
+    host-record=k8s-node01.kubernetes.net,k8s-node01,etcd-node01,192.168.0.81
+    host-record=k8s-node02.kubernetes.net,k8s-node02,etcd-node02,192.168.0.82
     log-queries
 ---
 apiVersion: apps/v1

--- a/pulsar-operators/configs/05-kafka-dns.yaml
+++ b/pulsar-operators/configs/05-kafka-dns.yaml
@@ -28,13 +28,22 @@ metadata:
   namespace: pulsar
   labels: { app: kafka-dnsmasq }
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels: { app: kafka-dnsmasq }
   template:
     metadata:
       labels: { app: kafka-dnsmasq }
     spec:
+      # Spread the 2 replicas one-per-node so a single node outage (e.g. node00)
+      # leaves a surviving DNS pod. ScheduleAnyway (not DoNotSchedule) so a pod
+      # still schedules if only one node is available rather than going Pending.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: { app: kafka-dnsmasq }
       containers:
         - name: dnsmasq
           image: 4km3/dnsmasq:2.90-r3
@@ -45,6 +54,14 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_BIND_SERVICE", "NET_ADMIN"]
+          # Pull a wedged pod from the LB's endpoints (readiness) and restart it
+          # (liveness) so the surviving replica keeps serving.
+          readinessProbe:
+            tcpSocket: { port: 53 }
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket: { port: 53 }
+            periodSeconds: 20
           volumeMounts:
             - { name: conf, mountPath: /etc/dnsmasq.conf, subPath: dnsmasq.conf }
       volumes:


### PR DESCRIPTION
## Summary
Makes the in-cluster Kafka DNS resolver (`kafka-dnsmasq`, from #24) highly available so it can safely serve as a LAN client's primary resolver.

- **2 replicas** (was 1) — a single node outage (e.g. the prior node00 incident) now leaves a serving pod.
- **One-per-node spread** via `topologySpreadConstraints` (maxSkew 1, `kubernetes.io/hostname`, `ScheduleAnyway`) — matches the broker/bookie convention; degrades to co-location rather than Pending if only one node is up.
- **tcp/53 readiness + liveness probes** — a wedged pod is pulled from the LoadBalancer endpoints (readiness) and restarted (liveness).

## Why
We're pointing the Kafka client machine's resolver directly at the dnsmasq VIP (`192.168.0.206`), so the single-pod SPOF needed to go.

## Verification (live)
- Both pods scheduled on **different nodes** (node00 + node02); 2 endpoints behind the VIP.
- `private-cloud-broker-0.kafka.lab` → `192.168.0.205` via the VIP.
- Client machine (resolver = `192.168.0.206`): `kafka.lab`/broker hosts → `192.168.0.205`, `google.com` still resolves (upstream forwarding intact).