### PR TITLE
Adopt <service>.<cluster>.internal DNS naming scheme

### DIFF
--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -141,7 +141,7 @@ spec:
     certSecretName: pulsar-server-tls
     trustCertsEnabled: true
   # External Kafka (KSN) via the Istio ingress gateway (TLS PASSTHROUGH, per-broker SNI).
-  # Clients reach broker-N.kafka.lab:9093 (SASL_SSL+token); the gateway SNI-routes to the
+  # Clients reach broker-N.kafka.private-cloud.internal:9093 (SASL_SSL+token); the gateway SNI-routes to the
   # broker's external KSN listener on :9095 which terminates TLS with kafka-broker-tls.
   # REQUIRES the per-pod ServiceEntries in 04-ksn-istio-gateway.yaml — the operator does NOT
   # generate them for advertisedListeners[].istioGateway (see docs/ksn-istio-gateway-bug-report.md).
@@ -149,7 +149,7 @@ spec:
   # 9095 is distinct from the internal KSN 9092; pulsar protocol disabled to avoid a 6651 double-bind.
   advertisedListeners:
     - name: external
-      hostTemplate: "$(POD_NAME).kafka.lab"
+      hostTemplate: "$(POD_NAME).kafka.private-cloud.internal"
       protocols:
         pulsar:
           enabled: false
@@ -159,7 +159,7 @@ spec:
           advertisedPort: 9093
           containerPort: 9095
       istioGateway:
-        clusterAddress: kafka.lab
+        clusterAddress: kafka.private-cloud.internal
         selector:
           istio: ingressgateway
         tls:

--- a/pulsar-operators/configs/04-ksn-istio-gateway.yaml
+++ b/pulsar-operators/configs/04-ksn-istio-gateway.yaml
@@ -11,7 +11,7 @@
 #          -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"kafka-tls","port":9093,"targetPort":9093,"protocol":"TCP"}}]'
 #   3) JKS keystore password secret referenced by the cert + kop.tls (keep out of git):
 #        kubectl create secret generic kafka-keystore-pass -n pulsar --from-literal=password='<choose-one>'
-#   4) Client DNS: kafka.lab + *.kafka.lab -> the istio-ingressgateway LB IP
+#   4) Client DNS: kafka.private-cloud.internal + *.kafka.private-cloud.internal -> the istio-ingressgateway LB IP
 #        (in-cluster dnsmasq, or /etc/hosts / hostAliases on the client).
 #   5) After installing Istio while the operator is already running, restart it so it
 #      re-detects the Istio CRDs:  kubectl rollout restart deploy/sn-operator -n operators
@@ -28,10 +28,10 @@ spec:
   issuerRef:
     name: pulsar-ca-issuer      # the CA issuer from 03-pulsar-tls.yaml
     kind: Issuer
-  commonName: kafka.lab
+  commonName: kafka.private-cloud.internal
   dnsNames:
-    - kafka.lab
-    - "*.kafka.lab"
+    - kafka.private-cloud.internal
+    - "*.kafka.private-cloud.internal"
   keystores:
     jks:
       create: true

--- a/pulsar-operators/configs/05-kafka-dns.yaml
+++ b/pulsar-operators/configs/05-kafka-dns.yaml
@@ -1,11 +1,13 @@
-# In-cluster dnsmasq that resolves the Kafka domain (and a few LAN infra names) for clients
-# with no DNS server of their own. Wildcards *.kafka.lab + kafka.lab to the Istio ingress
-# gateway LB IP, serves k8s-node/etcd host records, and forwards everything else upstream.
-# Point your client machine's resolver at this Service's LoadBalancer IP (192.168.0.206)
-# (no router conditional-forwarder needed).
+# In-cluster dnsmasq: the LAN edge resolver for clients with no DNS of their own.
+# Naming scheme is <service>.<cluster>.internal (.internal = ICANN-reserved private-use TLD):
+#   *.kafka.private-cloud.internal  -> Istio ingress gateway LB (per-broker SNI; wildcard for HPA)
+#   pulsar.private-cloud.internal   -> Pulsar proxy LB (single record; proxy fronts all brokers)
+# Plus k8s-node/etcd host records, and upstream forwarding for everything else.
+# Point your client machine's resolver at this Service's LoadBalancer IP (192.168.0.206).
+# Endpoint/IP registry: pulsar-operators/docs/lan-endpoints.md.
 #
 # Companion to 03/04-* (external Kafka via the Istio gateway).
-# IMPORTANT: set the gateway IP in the ConfigMap below to your istio-ingressgateway LB IP.
+# IMPORTANT: keep the LB IPs below in sync with the live Service EXTERNAL-IPs.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -18,8 +20,14 @@ data:
     no-hosts
     server=8.8.8.8
     server=1.1.1.1
-    # *.kafka.lab and kafka.lab -> the Istio ingress gateway LB IP
-    address=/kafka.lab/192.168.0.205
+    # Low TTL so clients re-resolve quickly if an ingress LB IP changes.
+    local-ttl=30
+    # Kafka (KSN): per-broker SNI passthrough, so the whole zone wildcards to the
+    # Istio ingress gateway LB (covers kafka.* bootstrap + *.kafka.* broker names,
+    # incl. HPA scale-up). address=/domain/ip matches the domain and all subdomains.
+    address=/kafka.private-cloud.internal/192.168.0.205
+    # Pulsar: proxy-fronted, so a single exact record (no wildcard) at the proxy LB.
+    host-record=pulsar.private-cloud.internal,192.168.0.200
     # LAN infrastructure records (mirror of the manual /etc/hosts on each node):
     # k8s node + etcd hostnames so clients using this resolver don't need their own
     # /etc/hosts entries. host-record gives forward A + reverse PTR; multiple names

--- a/pulsar-operators/docs/ksn-istio-gateway-bug-report.md
+++ b/pulsar-operators/docs/ksn-istio-gateway-bug-report.md
@@ -35,21 +35,21 @@ reconcilers and omits the ServiceEntry reconciler. This asymmetry is the bug.
    spec:
      advertisedListeners:
        - name: external
-         hostTemplate: "$(POD_NAME).kafka.lab"
+         hostTemplate: "$(POD_NAME).kafka.private-cloud.internal"
          protocols:
            pulsar: { enabled: false }
            kafka:  { enabled: true, scheme: SASL_SSL, advertisedPort: 9093, containerPort: 9095 }
          istioGateway:
-           clusterAddress: kafka.lab
+           clusterAddress: kafka.private-cloud.internal
            selector: { istio: ingressgateway }
            tls: { mode: PASSTHROUGH }
    ```
 
-4. Point `kafka.lab` and `*.kafka.lab` at the ingress gateway LB IP and run a Kafka client
+4. Point `kafka.private-cloud.internal` and `*.kafka.private-cloud.internal` at the ingress gateway LB IP and run a Kafka client
    (`security.protocol=SASL_SSL`, SASL/PLAIN token, PEM truststore of the cluster CA):
 
    ```bash
-   kafka-console-producer.sh --bootstrap-server kafka.lab:9093 --producer.config c.properties --topic t
+   kafka-console-producer.sh --bootstrap-server kafka.private-cloud.internal:9093 --producer.config c.properties --topic t
    ```
 
 ## Expected behavior
@@ -82,7 +82,7 @@ per-pod `outbound|9095||private-cloud-broker-0.private-cloud-broker-headless...`
 
 Kafka client:
 ```
-Connection to node ... (private-cloud-broker-0.kafka.lab/<gw-ip>:9093) terminated during authentication
+Connection to node ... (private-cloud-broker-0.kafka.private-cloud.internal/<gw-ip>:9093) terminated during authentication
 ... failed authentication due to: SSL handshake failed
 TimeoutException: Topic t not present in metadata after 60000 ms
 ```

--- a/pulsar-operators/docs/ksn-istio-gateway.md
+++ b/pulsar-operators/docs/ksn-istio-gateway.md
@@ -106,8 +106,8 @@ programmed.
    spec:
      secretName: kafka-broker-tls
      issuerRef: { name: pulsar-ca-issuer, kind: Issuer }
-     commonName: kafka.lab
-     dnsNames: ["kafka.lab", "*.kafka.lab"]
+     commonName: kafka.private-cloud.internal
+     dnsNames: ["kafka.private-cloud.internal", "*.kafka.private-cloud.internal"]
      keystores:
        jks:
          create: true
@@ -130,19 +130,19 @@ programmed.
              passwordSecretRef: { name: kafka-keystore-pass, key: password }
      advertisedListeners:
        - name: external
-         hostTemplate: "$(POD_NAME).kafka.lab"        # $(POD_ID) is NOT a broker env var
+         hostTemplate: "$(POD_NAME).kafka.private-cloud.internal"        # $(POD_ID) is NOT a broker env var
          protocols:
            pulsar: { enabled: false }                 # else an external pulsar listener double-binds 6651
            kafka:  { enabled: true, scheme: SASL_SSL, advertisedPort: 9093, containerPort: 9095 }
          istioGateway:
-           clusterAddress: kafka.lab
+           clusterAddress: kafka.private-cloud.internal
            selector: { istio: ingressgateway }
            tls: { mode: PASSTHROUGH }
    ```
 
 4. **Per-pod ServiceEntries** (the workaround above), one per replica.
 
-5. **Client DNS:** `kafka.lab` and `*.kafka.lab` → ingress gateway LB IP. Kafka client config:
+5. **Client DNS:** `kafka.private-cloud.internal` and `*.kafka.private-cloud.internal` → ingress gateway LB IP. Kafka client config:
    ```properties
    security.protocol=SASL_SSL
    sasl.mechanism=PLAIN

--- a/pulsar-operators/docs/lan-endpoints.md
+++ b/pulsar-operators/docs/lan-endpoints.md
@@ -1,0 +1,53 @@
+# LAN endpoints & DNS naming
+
+Single source of truth for the lab's externally-reachable IPs and the DNS names that
+front them. The names are served by the in-cluster dnsmasq edge resolver
+(`configs/05-kafka-dns.yaml`, LoadBalancer `192.168.0.206`); point a client's resolver
+at that IP to use them.
+
+## DNS naming scheme
+
+`<service>.<cluster>.internal`
+
+- **Root `.internal`** — the ICANN-reserved private-use TLD (the DNS analogue of RFC 1918
+  private IPs). Never delegated publicly, so no collision risk; certs must come from a
+  private CA (we use `pulsar-ca`), which is what we do anyway.
+- **`<service>` leftmost** — required by Kafka: KSN advertises per-broker names, so the
+  Kafka zone must be independently wildcardable (`*.kafka.<cluster>.internal`).
+- **`<cluster>`** = the Pulsar cluster name (`private-cloud`). Multi-cluster later is free:
+  `kafka.cluster-b.internal`.
+
+Wildcards only where membership is dynamic (Kafka brokers under HPA). Everything stable is
+an explicit record (safer — typos NXDOMAIN instead of silently resolving; gives reverse PTR).
+
+## Service endpoints
+
+| Name | IP | Ports | Backed by | Notes |
+|------|----|-------|-----------|-------|
+| `kafka.private-cloud.internal` (+ `*.`) | 192.168.0.205 | 9093 | `istio-ingressgateway` (istio-system) | KSN, SASL_SSL + `token:<jwt>`. Wildcard = per-broker SNI passthrough; tracks HPA scale-up. |
+| `pulsar.private-cloud.internal` | 192.168.0.200 | 6650 (binary), 8080 (admin) | `private-cloud-proxy-external` | Pulsar protocol, **plaintext + token** (proxy TLS not exposed externally — see follow-up #9). |
+| (snmcp) | 192.168.0.203 | 9090 | `snmcp` | StreamNative MCP server (`/mcp`); Bearer pulsar token passthrough. No DNS name yet. |
+| (dnsmasq) | 192.168.0.206 | 53 | `kafka-dnsmasq` | This resolver itself. |
+
+## Node / infra records (mirror of each node's `/etc/hosts`)
+
+| Names | IP |
+|-------|----|
+| `k8s-node00.kubernetes.net`, `k8s-node00`, `etcd-node00` | 192.168.0.80 |
+| `k8s-node01.kubernetes.net`, `k8s-node01`, `etcd-node01` | 192.168.0.81 |
+| `k8s-node02.kubernetes.net`, `k8s-node02`, `etcd-node02` | 192.168.0.82 |
+
+## Connection strings
+
+- **Kafka:** `kafka.private-cloud.internal:9093` — `security.protocol=SASL_SSL`,
+  `sasl.mechanism=PLAIN`, `password="token:<jwt>"`, PEM truststore = `pulsar-ca` `ca.crt`.
+- **Pulsar:** `pulsar://pulsar.private-cloud.internal:6650`, admin
+  `http://pulsar.private-cloud.internal:8080` — `AuthenticationToken` `<jwt>`.
+
+## Adding a future service (e.g. Flink, Spark)
+
+1. Expose it via a LoadBalancer (MetalLB) or an Istio gateway route; note the IP.
+2. Add a record to `configs/05-kafka-dns.yaml`: `host-record=flink.private-cloud.internal,<ip>`
+   (use `address=/.../` only if it needs a wildcard).
+3. Add a row to the **Service endpoints** table above.
+4. If it serves TLS, add its name to the relevant cert's SANs (private CA).


### PR DESCRIPTION
## Summary
Moves the lab's external endpoints from flat `kafka.lab` to a structured, extensible namespace: **`<service>.<cluster>.internal`** (`.internal` = the ICANN-reserved private-use TLD).

| Name | IP | Backed by |
|------|----|-----------|
| `kafka.private-cloud.internal` (+ `*.`) | 192.168.0.205 | Istio ingress gateway (per-broker SNI; wildcard tracks HPA) |
| `pulsar.private-cloud.internal` | 192.168.0.200 | Pulsar proxy LB (single record; proxy fronts brokers) |

## Changes
- **Kafka re-cut** (the only non-trivial rename — `kafka.lab` was baked into more than DNS):
  - broker CR `advertisedListeners[].hostTemplate` + `istioGateway.clusterAddress`
  - `kafka-broker-tls` cert SANs (re-issued: `kafka.private-cloud.internal`, `*.kafka.private-cloud.internal`)
  - operator auto-regenerated the per-broker Gateway/VirtualServices
- **dnsmasq** (`05-kafka-dns.yaml`): kafka wildcard moved; added `pulsar.private-cloud.internal` host-record; added `local-ttl=30`.
- **New** `docs/lan-endpoints.md`: single source of truth — IP registry, naming-scheme rationale, connection strings, and the procedure to add a future service (Flink/Spark).
- Swept `kafka.lab` → `kafka.private-cloud.internal` across configs + runbook + bug report.

## Verification (live, new names)
- Cert SANs re-issued and confirmed; operator regenerated routes for `kafka.private-cloud.internal` + both broker hosts.
- DNS resolves: kafka apex/brokers → .205, pulsar → .200.
- **Kafka** `kafka.private-cloud.internal:9093` (SASL_SSL+token): 3 produced + consumed.
- **Pulsar** `pulsar://pulsar.private-cloud.internal:6650` (plaintext+token, via proxy): 3 produced + consumed.