### PR TITLE
Document why FM ConfigMaps use the in-cluster FQDN (not the .internal LAN name)

### DIFF
--- a/function-mesh-operator/configs/00-config-maps.yaml
+++ b/function-mesh-operator/configs/00-config-maps.yaml
@@ -4,6 +4,11 @@ kind: ConfigMap
 metadata:
   name: pulsar
 data:
+  # In-cluster proxy FQDN ON PURPOSE — Function Mesh runners are in-cluster pods that
+  # resolve via CoreDNS. Do NOT change these to the pulsar.private-cloud.internal LAN
+  # name: that name lives only in the edge dnsmasq (NXDOMAIN in CoreDNS) and would also
+  # hairpin out to the MetalLB LB. The .internal names are for LAN clients only.
+  # See pulsar-operators/docs/lan-endpoints.md.
   webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local:8080
   brokerServiceURL: pulsar://private-cloud-proxy.pulsar.svc.cluster.local:6650
 ---

--- a/function-mesh-operator/configs/01-package-url-function.yaml
+++ b/function-mesh-operator/configs/01-package-url-function.yaml
@@ -19,6 +19,9 @@ metadata:
   name: pulsar-fn
   namespace: pulsar
 data:
+  # In-cluster proxy FQDN ON PURPOSE — the function pod resolves via CoreDNS. Do NOT change
+  # to the pulsar.private-cloud.internal LAN name (NXDOMAIN in CoreDNS; it lives only in the
+  # edge dnsmasq). See pulsar-operators/docs/lan-endpoints.md.
   # NOTE the TRAILING DOT on the host — marks the name absolute so the function pod's
   # resolver doesn't append the search domain (…svc.cluster.local.pulsar.svc.cluster.local).
   webServiceURL: http://private-cloud-proxy.pulsar.svc.cluster.local.:8080


### PR DESCRIPTION
## Summary
Doc-only. Adds a guard comment to both Function Mesh `pulsar` connection ConfigMaps (`00-config-maps.yaml`, `01-package-url-function.yaml`) explaining that the `private-cloud-proxy.pulsar.svc.cluster.local` FQDN is **deliberate**.

## Why
FM runners are in-cluster pods that resolve via CoreDNS. The new `pulsar.private-cloud.internal` LAN name lives only in the edge dnsmasq → **NXDOMAIN in CoreDNS** (verified from a pod), and would hairpin out to the MetalLB LB even if it resolved. The comment prevents a well-meaning swap to the `.internal` name that would break functions, and points to `docs/lan-endpoints.md` for the edge-vs-cluster DNS rationale.

No runtime change.