### PR TITLE
Enable MQTT (MoP) protocol: external LB + token auth + DNS

### DIFF
--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -181,6 +181,13 @@ spec:
           passwordSecretRef:
             name: kafka-keystore-pass
             key: password
+      # MQTT protocol (MoP). proxyEnabled exposes MQTT through the Pulsar proxy for
+      # external clients (the MoP proxy ships in this image, unlike the KoP proxy).
+      # Default broker MQTT listener :1883 (plaintext); external clients reach it via the
+      # proxy LB. Auth uses the cluster JWT (MQTT CONNECT password = the token).
+      mop:
+        enabled: true
+        proxyEnabled: true
     # Orca / Function Mesh Worker Service (FMWS): the bundled mesh-worker-service NAR
     # turns the broker's functions-worker into a translator — `pulsar-admin/snctl
     # functions create --jar` becomes a Function Mesh `Function` CRD (no hand-written
@@ -217,6 +224,13 @@ spec:
       PULSAR_PREFIX_proxyRoles: proxy-admin
       PULSAR_PREFIX_brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
       PULSAR_PREFIX_tokenPublicKey: file:///mnt/secrets/my-public.key
+      # --- MQTT (MoP) auth: enforce the cluster JWT on MQTT too ---
+      # MoP authentication defaults OFF even when Pulsar auth is on, so without these
+      # MQTT (broker :1883 and proxy :5682) is an UNAUTHENTICATED backdoor. With them,
+      # clients authenticate by sending the JWT as the MQTT CONNECT password.
+      PULSAR_PREFIX_mqttAuthenticationEnabled: "true"
+      PULSAR_PREFIX_mqttAuthenticationMethods: token
+      PULSAR_PREFIX_mqttAuthorizationEnabled: "true"
   pod:
     resources:
       requests:

--- a/pulsar-operators/configs/05-kafka-dns.yaml
+++ b/pulsar-operators/configs/05-kafka-dns.yaml
@@ -28,6 +28,9 @@ data:
     address=/kafka.private-cloud.internal/192.168.0.205
     # Pulsar: proxy-fronted, so a single exact record (no wildcard) at the proxy LB.
     host-record=pulsar.private-cloud.internal,192.168.0.200
+    # MQTT (MoP): single record at the dedicated MQTT LB (06-mqtt-external.yaml); the
+    # broker-side MoP proxy routes across brokers, so no wildcard/per-broker DNS needed.
+    host-record=mqtt.private-cloud.internal,192.168.0.207
     # LAN infrastructure records (mirror of the manual /etc/hosts on each node):
     # k8s node + etcd hostnames so clients using this resolver don't need their own
     # /etc/hosts entries. host-record gives forward A + reverse PTR; multiple names

--- a/pulsar-operators/configs/06-mqtt-external.yaml
+++ b/pulsar-operators/configs/06-mqtt-external.yaml
@@ -1,0 +1,35 @@
+# External MQTT (MoP) access.
+#
+# MoP is enabled on the broker via config.protocolHandlers.mop (03-pulsar-zookeeper.yaml):
+#   broker MQTT listener  : :1883  (per-broker; serves only that broker's topics)
+#   MoP routing proxy     : :5682  (mqttProxyEnable=true; routes across all brokers)
+# The MoP "proxy" runs ON THE BROKER PODS, not the Pulsar proxy — so the Pulsar proxy LB
+# (6650/8080) does NOT carry MQTT. We publish our own LoadBalancer here.
+#
+# Clients connect to the standard MQTT port 1883 on this LB; it forwards to the brokers'
+# MoP proxy (5682), which routes to whichever broker owns the topic. A single VIP works
+# (no per-broker SNI like Kafka) because the MoP proxy does the cross-broker routing.
+#
+# Auth: MoP enforces the cluster JWT (mqttAuthenticationEnabled in 03). MQTT clients send
+# the token as the CONNECT password. DNS: mqtt.private-cloud.internal -> this LB
+# (configs/05-kafka-dns.yaml). See pulsar-operators/docs/lan-endpoints.md.
+apiVersion: v1
+kind: Service
+metadata:
+  name: private-cloud-mqtt-external
+  namespace: pulsar
+  labels:
+    cloud.streamnative.io/cluster: private-cloud
+    cloud.streamnative.io/component: mqtt
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 192.168.0.207
+  selector:
+    cloud.streamnative.io/app: pulsar
+    cloud.streamnative.io/cluster: private-cloud
+    cloud.streamnative.io/component: broker
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: 5682     # brokers' MoP routing proxy (mqttProxyPort)
+      protocol: TCP

--- a/pulsar-operators/docs/lan-endpoints.md
+++ b/pulsar-operators/docs/lan-endpoints.md
@@ -26,6 +26,7 @@ an explicit record (safer — typos NXDOMAIN instead of silently resolving; give
 |------|----|-------|-----------|-------|
 | `kafka.private-cloud.internal` (+ `*.`) | 192.168.0.205 | 9093 | `istio-ingressgateway` (istio-system) | KSN, SASL_SSL + `token:<jwt>`. Wildcard = per-broker SNI passthrough; tracks HPA scale-up. |
 | `pulsar.private-cloud.internal` | 192.168.0.200 | 6650 (binary), 8080 (admin) | `private-cloud-proxy-external` | Pulsar protocol, **plaintext + token** (proxy TLS not exposed externally — see follow-up #9). |
+| `mqtt.private-cloud.internal` | 192.168.0.207 | 1883 → 5682 | `private-cloud-mqtt-external` | MQTT (MoP). LB forwards to the brokers' MoP routing proxy (5682). **Token auth** (JWT as the MQTT CONNECT password); single record (proxy routes across brokers). |
 | (snmcp) | 192.168.0.203 | 9090 | `snmcp` | StreamNative MCP server (`/mcp`); Bearer pulsar token passthrough. No DNS name yet. |
 | (dnsmasq) | 192.168.0.206 | 53 | `kafka-dnsmasq` | This resolver itself. |
 
@@ -43,6 +44,10 @@ an explicit record (safer — typos NXDOMAIN instead of silently resolving; give
   `sasl.mechanism=PLAIN`, `password="token:<jwt>"`, PEM truststore = `pulsar-ca` `ca.crt`.
 - **Pulsar:** `pulsar://pulsar.private-cloud.internal:6650`, admin
   `http://pulsar.private-cloud.internal:8080` — `AuthenticationToken` `<jwt>`.
+- **MQTT:** `mqtt.private-cloud.internal:1883` — MQTT CONNECT with any username and the
+  JWT as the **password** (MoP token auth). e.g.
+  `mosquitto_pub -h mqtt.private-cloud.internal -p 1883 -u user -P "<jwt>" -t mqtt-e2e -m hi`.
+  A plain MQTT topic (`mqtt-e2e`) maps to `persistent://public/default/mqtt-e2e`.
 
 ## Adding a future service (e.g. Flink, Spark)
 


### PR DESCRIPTION
## Summary
Enables the MQTT protocol (MoP) on the cluster with authenticated external access, following https://docs.streamnative.io/private-cloud/v2/configure-private-cloud/protocols/configure-mqtt-protocol plus the gaps that doc omits (ports, auth, external LB, DNS).

| Name | IP | Ports | Backed by |
|------|----|-------|-----------|
| `mqtt.private-cloud.internal` | 192.168.0.207 | 1883 → 5682 | `private-cloud-mqtt-external` (new LB → brokers' MoP routing proxy) |

## Changes
- **Broker** (`03-pulsar-zookeeper.yaml`): `config.protocolHandlers.mop {enabled: true, proxyEnabled: true}` → `messagingProtocols` gains `mqtt`; broker MQTT listener `:1883`, MoP routing proxy `:5682`. The MoP proxy runs **on the brokers** (not the Pulsar proxy), so a single LB VIP routes across brokers — no per-broker SNI like Kafka.
- **Security**: MoP authentication defaults **OFF** even when Pulsar auth is on — so MQTT would be an unauthenticated backdoor. Added `mqttAuthenticationEnabled` / `mqttAuthenticationMethods=token` / `mqttAuthorizationEnabled` so MQTT enforces the cluster JWT (token sent as the MQTT CONNECT password).
- **External LB** (new `06-mqtt-external.yaml`): `private-cloud-mqtt-external` at `192.168.0.207`, port `1883` → brokers' MoP proxy `5682`.
- **DNS** (`05-kafka-dns.yaml`): `mqtt.private-cloud.internal` host-record → `192.168.0.207`.
- **Docs**: `lan-endpoints.md` MQTT row + connection string.

## Verification (live)
- Broker logs: `Started MQTT Proxy on /0.0.0.0:5682`, MoP 4.2.1.4, `messagingProtocols=[kafka, mqtt]`.
- DNS resolves `mqtt.private-cloud.internal → 192.168.0.207`.
- **Negative**: `mosquitto_pub` with no token → `Connection Refused: bad user name or password`.
- **Positive**: token-authed `mosquitto_sub`/`mosquitto_pub` round-trip via `mqtt.private-cloud.internal:1883`.

## Follow-up (not in this PR)
- MQTT over TLS (8883) — would need a MoP TLS cert + `mqttProxyTlsEnabled`; currently plaintext+token like the Pulsar proxy path.