### PR TITLE
Enable Pulsar message REST API (HTTP produce/consume)

### DIFF
--- a/pulsar-operators/configs/03-pulsar-zookeeper.yaml
+++ b/pulsar-operators/configs/03-pulsar-zookeeper.yaml
@@ -231,6 +231,11 @@ spec:
       PULSAR_PREFIX_mqttAuthenticationEnabled: "true"
       PULSAR_PREFIX_mqttAuthenticationMethods: token
       PULSAR_PREFIX_mqttAuthorizationEnabled: "true"
+      # --- Message REST API: produce/consume over HTTP via the rest-servlet ---
+      # Served on the broker web port (8080); reached externally through the Pulsar proxy
+      # LB (pulsar.private-cloud.internal:8080). Token-authed like the rest of the cluster.
+      # POST /admin/rest/topics/v1/{domain}/{tenant}/{namespace}/{topic}/message
+      PULSAR_PREFIX_pulsarRestMessagingServiceEnabled: "true"
   pod:
     resources:
       requests:

--- a/pulsar-operators/docs/lan-endpoints.md
+++ b/pulsar-operators/docs/lan-endpoints.md
@@ -48,6 +48,16 @@ an explicit record (safer — typos NXDOMAIN instead of silently resolving; give
   JWT as the **password** (MoP token auth). e.g.
   `mosquitto_pub -h mqtt.private-cloud.internal -p 1883 -u user -P "<jwt>" -t mqtt-e2e -m hi`.
   A plain MQTT topic (`mqtt-e2e`) maps to `persistent://public/default/mqtt-e2e`.
+- **Message REST API:** over the Pulsar proxy web port `pulsar.private-cloud.internal:8080`,
+  `Authorization: Bearer <jwt>`. Enabled via `pulsarRestMessagingServiceEnabled` on the broker.
+  - Produce: `POST /admin/rest/topics/v1/persistent/public/default/<topic>/message`
+    (`Content-Type: application/octet-stream`, body = payload) → `201` + msg-id.
+  - Consume: `POST /admin/rest/topics/v1/persistent/public/default/<topic>/<sub>/message`
+    (body `{"timeoutMillis":3000}`) → `200` + payload (`204` if empty).
+  - **Gotcha:** auto-created topics are *partitioned* (`allowAutoTopicCreationType=partitioned`);
+    the REST API produces/consumes cleanly only on a **non-partitioned** topic. Pre-create it
+    (`PUT /admin/v2/persistent/public/default/<topic>` with a superuser token) or address
+    `<topic>-partition-0`. Plain produce auto-creates partitioned → consume returns 204.
 
 ## Adding a future service (e.g. Flink, Spark)
 


### PR DESCRIPTION
## Summary
Enables the **message REST API** (produce/consume over HTTP), per https://docs.streamnative.io/private-cloud/v2/configure-private-cloud/protocols/private-cloud-restapi. One broker flag; reuses the existing Pulsar proxy LB, so no new LB/DNS.

## Changes
- **Broker** (`03-pulsar-zookeeper.yaml`): `config.custom.PULSAR_PREFIX_pulsarRestMessagingServiceEnabled: "true"` — activates the `rest-servlet` (already present in `additionalServlets`). Served on the broker web port `8080`, reached externally via `pulsar.private-cloud.internal:8080` (the Pulsar proxy LB forwards to the broker). Token-authed.
- **Docs** (`lan-endpoints.md`): REST produce/consume endpoints + connection notes.

## Verification (live, per the reference doc methodology)
- Negative (no token) → `401`.
- Produce `POST /admin/rest/topics/v1/persistent/public/default/<topic>/message` → `201` + msg-id `178:0:-1`.
- Consume `POST /admin/rest/topics/v1/persistent/public/default/<topic>/<sub>/message` (`{"timeoutMillis":...}`) → `200`, payload `Hello-REST-e2e-np2` round-tripped.

## Gotcha (documented)
Auto-created topics are **partitioned** (`allowAutoTopicCreationType=partitioned`); the REST API produces/consumes cleanly only on a **non-partitioned** topic (pre-create with a superuser token, or address `<topic>-partition-0`). Otherwise consume returns `204`.